### PR TITLE
Remove dead code, unneeded casts and add annotations

### DIFF
--- a/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
@@ -10,7 +10,6 @@ import org.yaml.snakeyaml.error.YAMLException;
 import backtype.storm.Config;
 import backtype.storm.LocalCluster;
 import backtype.storm.StormSubmitter;
-import backtype.storm.generated.KillOptions;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.topology.BoltDeclarer;
 import backtype.storm.topology.IRichBolt;
@@ -18,7 +17,6 @@ import backtype.storm.topology.IRichSpout;
 import backtype.storm.topology.SpoutDeclarer;
 import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.tuple.Fields;
-import backtype.storm.utils.Utils;
 import storm.kafka.KafkaSpout;
 import storm.kafka.KeyValueSchemeAsMultiScheme;
 import storm.kafka.SpoutConfig;
@@ -44,8 +42,8 @@ public class PyleusTopologyBuilder {
     public static void handleBolt(final TopologyBuilder builder, final BoltSpec spec,
         final TopologySpec topologySpec) {
 
-        PythonBolt bolt = pyFactory.createPythonBolt((String) spec.module,
-            (Map<String, Object>) spec.options, (String) topologySpec.logging_config, (String) topologySpec.serializer);
+        PythonBolt bolt = pyFactory.createPythonBolt(spec.module,
+                spec.options, topologySpec.logging_config, topologySpec.serializer);
 
         if (spec.output_fields != null) {
             bolt.setOutputFields(spec.output_fields);
@@ -57,7 +55,7 @@ public class PyleusTopologyBuilder {
 
         IRichBolt stormBolt = bolt;
 
-        BoltDeclarer declarer = null;
+        BoltDeclarer declarer;
         if (spec.parallelism_hint != -1) {
             declarer = builder.setBolt(spec.name, stormBolt, spec.parallelism_hint);
         } else {
@@ -71,6 +69,7 @@ public class PyleusTopologyBuilder {
         for (Map<String, Object> grouping : spec.groupings) {
             Map.Entry<String, Object> entry = grouping.entrySet().iterator().next();
             String groupingType = entry.getKey();
+            @SuppressWarnings("unchecked")
             Map<String, Object> groupingMap = (Map<String, Object>) entry.getValue();
             String component = (String) groupingMap.get("component");
             String stream = (String) groupingMap.get("stream");
@@ -80,6 +79,7 @@ public class PyleusTopologyBuilder {
             } else if (groupingType.equals("global_grouping")) {
                 declarer.globalGrouping(component, stream);
             } else if (groupingType.equals("fields_grouping")) {
+                @SuppressWarnings("unchecked")
                 List<String> fields = (List<String>) groupingMap.get("fields");
                 String[] fieldsArray = fields.toArray(new String[fields.size()]);
                 declarer.fieldsGrouping(component, stream, new Fields(fieldsArray));
@@ -105,7 +105,7 @@ public class PyleusTopologyBuilder {
             spout = handlePythonSpout(builder, spec, topologySpec);
         }
 
-        SpoutDeclarer declarer = null;
+        SpoutDeclarer declarer;
         if (spec.parallelism_hint != -1) {
             declarer = builder.setSpout(spec.name, spout, spec.parallelism_hint);
         } else {
@@ -117,7 +117,9 @@ public class PyleusTopologyBuilder {
         }
     }
 
-    public static IRichSpout handleKafkaSpout(final TopologyBuilder builder, final SpoutSpec spec) {
+    public static IRichSpout handleKafkaSpout(
+            @SuppressWarnings("unused") final TopologyBuilder builder,
+            final SpoutSpec spec) {
         String topic = (String) spec.options.get("topic");
         if (topic == null) {
             throw new RuntimeException("Kafka spout must have topic");
@@ -163,11 +165,13 @@ public class PyleusTopologyBuilder {
         return new KafkaSpout(config);
     }
 
-    public static IRichSpout handlePythonSpout(final TopologyBuilder builder, final SpoutSpec spec,
-        final TopologySpec topologySpec) {
+    public static IRichSpout handlePythonSpout(
+            @SuppressWarnings("unused") final TopologyBuilder builder,
+            final SpoutSpec spec,
+            final TopologySpec topologySpec) {
 
-        PythonSpout spout = pyFactory.createPythonSpout((String) spec.module,
-            (Map<String, Object>) spec.options, (String) topologySpec.logging_config, (String) topologySpec.serializer);
+        PythonSpout spout = pyFactory.createPythonSpout(spec.module,
+                spec.options, topologySpec.logging_config, topologySpec.serializer);
 
         if (spec.output_fields != null) {
             spout.setOutputFields(spec.output_fields);

--- a/topology_builder/src/main/java/com/yelp/pyleus/PythonComponentsFactory.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/PythonComponentsFactory.java
@@ -10,7 +10,6 @@ import com.yelp.pyleus.spout.PythonSpout;
 
 public class PythonComponentsFactory {
 
-    public static final String VIRTUALENV_PATH = "/resources/pyleus_venv/bin/python";
     public static final String VIRTUALENV_INTERPRETER = "pyleus_venv/bin/python";
     public static final String MODULE_OPTION = "-m";
 

--- a/topology_builder/src/main/java/com/yelp/pyleus/bolt/PythonBolt.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/bolt/PythonBolt.java
@@ -30,6 +30,7 @@ public class PythonBolt extends ShellBolt implements IRichBolt {
         } else {
             for (Entry<String, Object> outEntry : this.outputFields.entrySet()) {
                 String stream = outEntry.getKey();
+                @SuppressWarnings("unchecked")
                 List<String> fields = (List<String>) outEntry.getValue();
                 declarer.declareStream(stream, new Fields(fields.toArray(new String[fields.size()])));
             }

--- a/topology_builder/src/main/java/com/yelp/pyleus/serializer/MessagePackSerializer.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/serializer/MessagePackSerializer.java
@@ -20,7 +20,6 @@ import backtype.storm.utils.Utils;
 import org.apache.log4j.Logger;
 import org.msgpack.MessagePack;
 import org.msgpack.template.Template;
-import org.msgpack.type.ValueType;
 
 import static org.msgpack.template.Templates.tMap;
 import static org.msgpack.template.Templates.TString;
@@ -46,6 +45,7 @@ public class MessagePackSerializer implements ISerializer {
         this.listTmpl = tList(TValue);
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, Object> getMapFromContext(TopologyContext context) {
         Map context_map = new HashMap();
         context_map.put("taskid", context.getThisTaskId());
@@ -66,7 +66,7 @@ public class MessagePackSerializer implements ISerializer {
 
         Map<String, Value> pidmsg = readMessage();
         Value pid = pidmsg.get("pid");
-        return (Number) pid.asIntegerValue().getInt();
+        return pid.asIntegerValue().getInt();
     }
 
     @Override

--- a/topology_builder/src/main/java/com/yelp/pyleus/spec/SpoutSpec.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/spec/SpoutSpec.java
@@ -1,6 +1,5 @@
 package com.yelp.pyleus.spec;
 
-import java.util.List;
 import java.util.Map;
 
 public class SpoutSpec {

--- a/topology_builder/src/main/java/com/yelp/pyleus/spec/TopologySpec.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/spec/TopologySpec.java
@@ -29,6 +29,7 @@ public class TopologySpec {
     public Integer max_shellbolt_pending = DEFAULT_MAX_SHELLBOLT_PENDING;
     public String serializer = MSGPACK_SERIALIZER;
     public String logging_config;
+    @SuppressWarnings("unused")
     public String requirements_filename; // Not used in Java.
 
     private static Constructor getConstructor() {

--- a/topology_builder/src/main/java/com/yelp/pyleus/spout/PythonSpout.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/spout/PythonSpout.java
@@ -26,6 +26,7 @@ public class PythonSpout extends ShellSpout implements IRichSpout {
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         for(Entry<String, Object> outEntry : this.outputFields.entrySet()) {
             String stream = outEntry.getKey();
+            @SuppressWarnings("unchecked")
             List<String> fields = (List<String>) outEntry.getValue();
             declarer.declareStream(stream, new Fields(fields.toArray(new String[fields.size()])));
         }


### PR DESCRIPTION
- Dead code is what it says: imports that were not used and local variable initializers that were not needed
- Unneeded casts is self-explanatory
- Added `unchecked` annotations where types were not enforceable by the compiler
- Added `unused` annotations for items that the editor was not able to prove are in use
