### PR TITLE
Fix base jar installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+/pyleus/pyleus-base.jar
+.*.swp
+
+#
+# From https://github.com/github/gitignore/blob/master/Python.gitignore
+#
+
 *.py[cod]
 
 # C extensions
@@ -34,6 +41,3 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
-
-# Other
-.*.swp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include topology_builder/dist/pyleus-base.jar
+include pyleus/pyleus-base.jar
 include LICENSE
 include README.rst

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ clean:
 	rm -rf build/ dist/ pyleus.egg-info/ .tox/
 	find . -name '*.pyc' -delete
 	make -C topology_builder/ clean
+	rm -f pyleus/pyleus-base.jar
 	rm -rf docs/build/
 
 docs:

--- a/pyleus/__init__.py
+++ b/pyleus/__init__.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import
 
-import os
-import sys
+import pkg_resources
 
 __version__ = '0.2'
 
 BASE_JAR = "pyleus-base.jar"
-BASE_JAR_INSTALL_DIR = "share/pyleus"
-BASE_JAR_PATH = os.path.join(sys.prefix, BASE_JAR_INSTALL_DIR, BASE_JAR)
+BASE_JAR_PATH = pkg_resources.resource_filename('pyleus', BASE_JAR)

--- a/pyleus/_base_jar.py
+++ b/pyleus/_base_jar.py
@@ -1,0 +1,10 @@
+"""This module is used only by pyleus.cli.build._remove_pyleus_base_jar to
+determine the value of BASE_JAR_PATH inside _another_ virtualenv, so it can be
+removed to save space.
+"""
+from __future__ import absolute_import
+
+import pyleus
+
+if __name__ == '__main__':
+    print pyleus.BASE_JAR_PATH

--- a/pyleus/cli/build.py
+++ b/pyleus/cli/build.py
@@ -15,8 +15,6 @@ import yaml
 import zipfile
 
 from pyleus import __version__
-from pyleus import BASE_JAR
-from pyleus import BASE_JAR_INSTALL_DIR
 from pyleus.cli.topology_spec import TopologySpec
 from pyleus.cli.virtualenv_proxy import VirtualenvProxy
 from pyleus.storm.component import DESCRIBE_OPT
@@ -79,7 +77,8 @@ def _remove_pyleus_base_jar(venv):
     """Remove the Pyleus base jar from the virtualenv since it's redundant and
     takes up space. See PYLEUS-74.
     """
-    base_jar_path = os.path.join(venv.path, BASE_JAR_INSTALL_DIR, BASE_JAR)
+    base_jar_path = venv.execute_module("pyleus._base_jar",
+                                        cwd=venv.path).strip()
     os.remove(base_jar_path)
 
 

--- a/pyleus/cli/virtualenv_proxy.py
+++ b/pyleus/cli/virtualenv_proxy.py
@@ -92,10 +92,13 @@ class VirtualenvProxy(object):
             err_msg="Failed to install dependencies for this topology."
             " Run with --verbose for detailed info.")
 
-    def execute_module(self, module, args, cwd=None):
+    def execute_module(self, module, args=None, cwd=None):
         """Call "virtualenv/interpreter -m" to execute a python module."""
         cmd = [os.path.join(self.path, "bin", "python"), "-m", module]
-        cmd += args
+
+        if args:
+            cmd += args
+
         proc = subprocess.Popen(cmd,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from distutils.command.bdist import bdist as _bdist
 from distutils.core import Command
 import os
+import shutil
 import subprocess
 import sys
 
@@ -8,10 +9,11 @@ from setuptools import setup
 from setuptools.command.sdist import sdist as _sdist
 
 from pyleus import __version__
-from pyleus import BASE_JAR, BASE_JAR_INSTALL_DIR
+from pyleus import BASE_JAR
 
 JAVA_SRC_DIR = "topology_builder/"
 BASE_JAR_SRC = os.path.join(JAVA_SRC_DIR, "dist", BASE_JAR)
+BASE_JAR_DST = os.path.join("pyleus", BASE_JAR)
 
 
 class build_java(Command):
@@ -28,8 +30,12 @@ class build_java(Command):
     def _make_jar(self):
         subprocess.check_call(["make", "-C", JAVA_SRC_DIR])
 
+    def _copy_jar(self):
+        shutil.copy(BASE_JAR_SRC, BASE_JAR_DST)
+
     def run(self):
         self._make_jar()
+        self._copy_jar()
 
 
 class bdist(_bdist):
@@ -87,7 +93,7 @@ setup(
         "PyYAML",
         "msgpack-python",
     ] + extra_install_requires,
-    data_files=[(BASE_JAR_INSTALL_DIR, [BASE_JAR_SRC])],
+    package_data={'pyleus': [BASE_JAR]},
     cmdclass={
         'build_java': build_java,
         'bdist': bdist,


### PR DESCRIPTION
Previously, pyleus-base.jar was installed to sys.prefix + '/share/pyleus/
pyleus-base.jar', and this worked fine when Pyleus was installed in a
virtualenv or via an fpm-created deb. In the former case, the jar was
installed to $VIRTUAL_ENV/share/pyleus/pyleus-base.jar, and in the latter,
it made its way to /usr/share/pyleus/pyleus-base.jar.

However, if a user just ran 'pip install pyleus' on their system, the jar
would actually be installed to /usr/local/share/pyleus/pyleus-base.jar,
even though sys.prefix was just '/usr' when pyleus was executed.

Pyleus would thus look in /usr/share/pyleus and fail when it couldn't find
the base jar.

This change uses the seemingly preferred method of including the jar
within the package itself, and using the pkg_resources module to construct
its filesystem path.

The build step of removing the base jar from a topology jar (since it is
unneeded and takes up space) required modification as well.

Closes #24
