### PR TITLE
Rename 'storm_cluster_ip' config var to 'nimbus'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Or, submit to a Storm cluster with:
 
 .. code-block:: shell
 
-   $ pyleus submit -n NIMBUS_IP exclamation_topology.jar
+   $ pyleus submit -n NIMBUS exclamation_topology.jar
 
 The `examples`_ directory contains several annotated Pyleus topologies that try to cover as many Pyleus features as possible.
 
@@ -83,19 +83,19 @@ Pyleus command line interface
 
   .. code-block:: shell
 
-     $ pyleus submit [-n NIMBUS_IP] /path/to/pyleus_topology.yaml
+     $ pyleus submit [-n NIMBUS] /path/to/pyleus_topology.yaml
 
 * List all topologies running on a Storm cluster:
 
   .. code-block:: shell
 
-     $ pyleus list [-n NIMBUS_IP]
+     $ pyleus list [-n NIMBUS]
 
 * Kill a topology running on a Storm cluster:
 
   .. code-block:: shell
 
-     $ pyleus kill [-n NIMBUS_IP] TOPOLOGY_NAME
+     $ pyleus kill [-n NIMBUS] TOPOLOGY_NAME
 
 Try ``pyleus -h`` for a list of all the available commands or ``pyleus CMD -h`` for any command-specific help.
 

--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ You can set default values for many configuration options by placing a ``.pyleus
 .. code-block:: none
 
    [storm]
-   nimbus_ip: 10.11.12.13
+   nimbus: 10.11.12.13
    jvm_opts: -Djava.io.tmpdir=/home/myuser/tmp
 
    [build]

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -32,19 +32,19 @@ Command Line
 
   .. code-block:: none
 
-     pyleus submit [-n NIMBUS_IP] /path/to/pyleus_topology.yaml
+     pyleus submit [-n NIMBUS] /path/to/pyleus_topology.yaml
 
 * List all topologies running on a Storm cluster:
 
   .. code-block:: none
 
-     pyleus list [-n NIMBUS_IP]
+     pyleus list [-n NIMBUS]
 
 * Kill a topology running on a Storm cluster:
 
   .. code-block:: none
 
-     pyleus kill [-n NIMBUS_IP] TOPOLOGY_NAME [-w WAIT_TIME]
+     pyleus kill [-n NIMBUS] TOPOLOGY_NAME [-w WAIT_TIME]
 
   Option ``--wait-time`` overrides the duration in seconds Storm waits between deactivation and shutdown. Storm's default is 30 seconds.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ Run the example on a Storm cluster:
 
 .. code-block:: none
 
-   $ pyleus submit -n NIMBUS_IP exclamation_topology.jar
+   $ pyleus submit -n NIMBUS exclamation_topology.jar
 
 Documentation
 -------------

--- a/pyleus/cli/commands/kill_subcommand.py
+++ b/pyleus/cli/commands/kill_subcommand.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from pyleus.cli.commands.subcommand import SubCommand
-from pyleus.cli.topologies import add_storm_cluster_ip_argument
+from pyleus.cli.topologies import add_nimbus_argument
 from pyleus.cli.topologies import kill_topology
 
 
@@ -21,7 +21,7 @@ class KillSubCommand(SubCommand):
             "-w", "--wait-time", dest="wait_time",
             help="Override the duration in seconds Storm waits between "
                  "deactivation and shutdown.")
-        add_storm_cluster_ip_argument(parser)
+        add_nimbus_argument(parser)
 
     def run(self, configs):
         kill_topology(configs)

--- a/pyleus/cli/commands/list_subcommand.py
+++ b/pyleus/cli/commands/list_subcommand.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from pyleus.cli.commands.subcommand import SubCommand
-from pyleus.cli.topologies import add_storm_cluster_ip_argument
+from pyleus.cli.topologies import add_nimbus_argument
 from pyleus.cli.topologies import list_topologies
 
 
@@ -14,7 +14,7 @@ class ListSubCommand(SubCommand):
     DESCRIPTION = "List all topologies running on a Storm cluster"
 
     def add_arguments(self, parser):
-        add_storm_cluster_ip_argument(parser)
+        add_nimbus_argument(parser)
 
     def run(self, configs):
         list_topologies(configs)

--- a/pyleus/cli/commands/submit_subcommand.py
+++ b/pyleus/cli/commands/submit_subcommand.py
@@ -5,7 +5,7 @@ Args:
 """
 from __future__ import absolute_import
 
-from pyleus.cli.topologies import add_storm_cluster_ip_argument
+from pyleus.cli.topologies import add_nimbus_argument
 from pyleus.cli.topologies import submit_topology
 from pyleus.cli.commands.run_subcommand import RunSubCommand
 
@@ -17,7 +17,7 @@ class SubmitSubCommand(RunSubCommand):
     DESCRIPTION = "Submit a Pyleus topology to a Storm cluster"
 
     def add_specific_arguments(self, parser):
-        add_storm_cluster_ip_argument(parser)
+        add_nimbus_argument(parser)
 
     def run_topology(self, jar_path, configs):
         submit_topology(jar_path, configs)

--- a/pyleus/cli/storm_cluster.py
+++ b/pyleus/cli/storm_cluster.py
@@ -48,18 +48,19 @@ class StormCluster(object):
     """Object representing an interface to a Storm cluster.
     All the requests are basically translated into Storm commands.
     """
-    def __init__(self, storm_cmd_path, nimbus_ip, verbose, jvm_opts):
+
+    def __init__(self, storm_cmd_path, nimbus, verbose, jvm_opts):
         """Create the cluster object."""
 
         self.storm_cmd_path = storm_cmd_path
 
-        if nimbus_ip is None:
+        if nimbus is None:
             raise ConfigurationError(
                 "You must specify a storm cluster IP address."
                 " Use option <storm_cluster_ip> in the configuration file"
                 " or the command line option --storm-cluster")
 
-        self.nimbus_ip = nimbus_ip
+        self.nimbus = nimbus
         self.verbose = verbose
         self.jvm_opts = jvm_opts
 
@@ -73,7 +74,7 @@ class StormCluster(object):
 
         storm_cmd = [self.storm_cmd_path]
         storm_cmd += cmd
-        storm_cmd += ["-c", "nimbus.host={0}".format(self.nimbus_ip)]
+        storm_cmd += ["-c", "nimbus.host={0}".format(self.nimbus)]
 
         env = _get_storm_cmd_env(self.jvm_opts)
 

--- a/pyleus/cli/storm_cluster.py
+++ b/pyleus/cli/storm_cluster.py
@@ -56,9 +56,9 @@ class StormCluster(object):
 
         if nimbus is None:
             raise ConfigurationError(
-                "You must specify a storm cluster IP address."
-                " Use option <storm_cluster_ip> in the configuration file"
-                " or the command line option --storm-cluster")
+                "You must specify a Nimbus address. Use the option "
+                "<nimbus> in the configuration file or the command line "
+                "option -n/--nimbus.")
 
         self.nimbus = nimbus
         self.verbose = verbose

--- a/pyleus/cli/topologies.py
+++ b/pyleus/cli/topologies.py
@@ -8,12 +8,12 @@ from pyleus.cli.storm_cluster import LocalStormCluster
 from pyleus.cli.storm_cluster import StormCluster
 
 
-def add_storm_cluster_ip_argument(parser):
+def add_nimbus_argument(parser):
     """Add to the command parser an option in order to specify the cluster
     ip address from command line.
     """
     parser.add_argument(
-        "-n", "--nimbus", dest="storm_cluster_ip", metavar="NIMBUS",
+        "-n", "--nimbus", dest="nimbus", metavar="NIMBUS",
         help="The hostname or IP address of the Storm cluster's Nimbus node")
 
 
@@ -30,7 +30,7 @@ def submit_topology(jar_path, configs):
     """Submit the topology jar to the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.storm_cluster_ip,
+        configs.nimbus,
         configs.verbose,
         configs.jvm_opts).submit(jar_path)
 
@@ -39,7 +39,7 @@ def list_topologies(configs):
     """List the topologies running on the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.storm_cluster_ip,
+        configs.nimbus,
         configs.verbose,
         configs.jvm_opts).list()
 
@@ -48,7 +48,7 @@ def kill_topology(configs):
     """Kill a topology running on the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.storm_cluster_ip,
+        configs.nimbus,
         configs.verbose,
         configs.jvm_opts).kill(configs.topology_name, configs.wait_time)
 

--- a/pyleus/configuration.py
+++ b/pyleus/configuration.py
@@ -26,7 +26,7 @@ invocations.
    storm_cmd_path: /usr/share/storm/bin/storm
 
    # optional: use -n option of pyleus CLI instead
-   nimbus_ip: 10.11.12.13
+   nimbus: 10.11.12.13
 
    # java options to pass to Storm CLI
    jvm_opts: -Djava.io.tmpdir=/home/myuser/tmp
@@ -63,8 +63,8 @@ CONFIG_FILES_PATH = [
 Configuration = collections.namedtuple(
     "Configuration",
     "base_jar config_file debug func include_packages output_jar \
-     pypi_index_url storm_cluster_ip storm_cmd_path system_site_packages \
-     topology_path topology_jar topology_name verbose wait_time jvm_opts"
+     pypi_index_url nimbus storm_cmd_path system_site_packages topology_path \
+     topology_jar topology_name verbose wait_time jvm_opts"
 )
 """Namedtuple containing all pyleus configuration values."""
 
@@ -77,7 +77,7 @@ DEFAULTS = Configuration(
     include_packages=None,
     output_jar=None,
     pypi_index_url=None,
-    storm_cluster_ip=None,
+    nimbus=None,
     storm_cmd_path=None,
     system_site_packages=False,
     topology_path="pyleus_topology.yaml",


### PR DESCRIPTION
Previously, we changed on the CLI option from --storm-cluster to --nimbus
without modifying pyleus.configuration.

This brings in sync the CLI option and config var.

Closes #2
