### PR TITLE
Add nimbus port option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ You can set default values for many configuration options by placing a ``.pyleus
 .. code-block:: none
 
    [storm]
-   nimbus: 10.11.12.13
+   nimbus_host: 10.11.12.13
    jvm_opts: -Djava.io.tmpdir=/home/myuser/tmp
 
    [build]

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Or, submit to a Storm cluster with:
 
 .. code-block:: shell
 
-   $ pyleus submit -n NIMBUS exclamation_topology.jar
+   $ pyleus submit -n NIMBUS_HOST exclamation_topology.jar
 
 The `examples`_ directory contains several annotated Pyleus topologies that try to cover as many Pyleus features as possible.
 
@@ -83,19 +83,19 @@ Pyleus command line interface
 
   .. code-block:: shell
 
-     $ pyleus submit [-n NIMBUS] /path/to/pyleus_topology.yaml
+     $ pyleus submit [-n NIMBUS_HOST] /path/to/pyleus_topology.yaml
 
 * List all topologies running on a Storm cluster:
 
   .. code-block:: shell
 
-     $ pyleus list [-n NIMBUS]
+     $ pyleus list [-n NIMBUS_HOST]
 
 * Kill a topology running on a Storm cluster:
 
   .. code-block:: shell
 
-     $ pyleus kill [-n NIMBUS] TOPOLOGY_NAME
+     $ pyleus kill [-n NIMBUS_HOST] TOPOLOGY_NAME
 
 Try ``pyleus -h`` for a list of all the available commands or ``pyleus CMD -h`` for any command-specific help.
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Or, submit to a Storm cluster with:
 
 .. code-block:: shell
 
-   $ pyleus submit -n NIMBUS_IP exclamation_topology.jar
+   $ pyleus submit -n NIMBUS exclamation_topology.jar
 
 The `examples`_ directory contains several annotated Pyleus topologies that try to cover as many Pyleus features as possible.
 
@@ -83,19 +83,19 @@ Pyleus command line interface
 
   .. code-block:: shell
 
-     $ pyleus submit [-n NIMBUS_IP] /path/to/pyleus_topology.yaml
+     $ pyleus submit [-n NIMBUS] /path/to/pyleus_topology.yaml
 
 * List all topologies running on a Storm cluster:
 
   .. code-block:: shell
 
-     $ pyleus list [-n NIMBUS_IP]
+     $ pyleus list [-n NIMBUS]
 
 * Kill a topology running on a Storm cluster:
 
   .. code-block:: shell
 
-     $ pyleus kill [-n NIMBUS_IP] TOPOLOGY_NAME
+     $ pyleus kill [-n NIMBUS] TOPOLOGY_NAME
 
 Try ``pyleus -h`` for a list of all the available commands or ``pyleus CMD -h`` for any command-specific help.
 

--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ You can set default values for many configuration options by placing a ``.pyleus
 .. code-block:: none
 
    [storm]
-   nimbus_ip: 10.11.12.13
+   nimbus: 10.11.12.13
    jvm_opts: -Djava.io.tmpdir=/home/myuser/tmp
 
    [build]

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -32,19 +32,19 @@ Command Line
 
   .. code-block:: none
 
-     pyleus submit [-n NIMBUS_IP] /path/to/pyleus_topology.yaml
+     pyleus submit [-n NIMBUS] /path/to/pyleus_topology.yaml
 
 * List all topologies running on a Storm cluster:
 
   .. code-block:: none
 
-     pyleus list [-n NIMBUS_IP]
+     pyleus list [-n NIMBUS]
 
 * Kill a topology running on a Storm cluster:
 
   .. code-block:: none
 
-     pyleus kill [-n NIMBUS_IP] TOPOLOGY_NAME [-w WAIT_TIME]
+     pyleus kill [-n NIMBUS] TOPOLOGY_NAME [-w WAIT_TIME]
 
   Option ``--wait-time`` overrides the duration in seconds Storm waits between deactivation and shutdown. Storm's default is 30 seconds.
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -32,19 +32,19 @@ Command Line
 
   .. code-block:: none
 
-     pyleus submit [-n NIMBUS_HOST] /path/to/pyleus_topology.yaml
+     pyleus submit [-n NIMBUS_HOST] [-p NIMBUS_PORT] /path/to/pyleus_topology.yaml
 
 * List all topologies running on a Storm cluster:
 
   .. code-block:: none
 
-     pyleus list [-n NIMBUS_HOST]
+     pyleus list [-n NIMBUS_HOST] [-p NIMBUS_PORT]
 
 * Kill a topology running on a Storm cluster:
 
   .. code-block:: none
 
-     pyleus kill [-n NIMBUS_HOST] TOPOLOGY_NAME [-w WAIT_TIME]
+     pyleus kill [-n NIMBUS_HOST] [-p NIMBUS_PORT] TOPOLOGY_NAME [-w WAIT_TIME]
 
   Option ``--wait-time`` overrides the duration in seconds Storm waits between deactivation and shutdown. Storm's default is 30 seconds.
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -32,19 +32,19 @@ Command Line
 
   .. code-block:: none
 
-     pyleus submit [-n NIMBUS] /path/to/pyleus_topology.yaml
+     pyleus submit [-n NIMBUS_HOST] /path/to/pyleus_topology.yaml
 
 * List all topologies running on a Storm cluster:
 
   .. code-block:: none
 
-     pyleus list [-n NIMBUS]
+     pyleus list [-n NIMBUS_HOST]
 
 * Kill a topology running on a Storm cluster:
 
   .. code-block:: none
 
-     pyleus kill [-n NIMBUS] TOPOLOGY_NAME [-w WAIT_TIME]
+     pyleus kill [-n NIMBUS_HOST] TOPOLOGY_NAME [-w WAIT_TIME]
 
   Option ``--wait-time`` overrides the duration in seconds Storm waits between deactivation and shutdown. Storm's default is 30 seconds.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ Run the example on a Storm cluster:
 
 .. code-block:: none
 
-   $ pyleus submit -n NIMBUS exclamation_topology.jar
+   $ pyleus submit -n NIMBUS_HOST exclamation_topology.jar
 
 Documentation
 -------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ Run the example on a Storm cluster:
 
 .. code-block:: none
 
-   $ pyleus submit -n NIMBUS_IP exclamation_topology.jar
+   $ pyleus submit -n NIMBUS exclamation_topology.jar
 
 Documentation
 -------------

--- a/pyleus/cli/commands/kill_subcommand.py
+++ b/pyleus/cli/commands/kill_subcommand.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from pyleus.cli.commands.subcommand import SubCommand
-from pyleus.cli.topologies import add_storm_cluster_ip_argument
+from pyleus.cli.topologies import add_nimbus_argument
 from pyleus.cli.topologies import kill_topology
 
 
@@ -21,7 +21,7 @@ class KillSubCommand(SubCommand):
             "-w", "--wait-time", dest="wait_time",
             help="Override the duration in seconds Storm waits between "
                  "deactivation and shutdown.")
-        add_storm_cluster_ip_argument(parser)
+        add_nimbus_argument(parser)
 
     def run(self, configs):
         kill_topology(configs)

--- a/pyleus/cli/commands/kill_subcommand.py
+++ b/pyleus/cli/commands/kill_subcommand.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from pyleus.cli.commands.subcommand import SubCommand
-from pyleus.cli.topologies import add_nimbus_argument
+from pyleus.cli.topologies import add_nimbus_arguments
 from pyleus.cli.topologies import kill_topology
 
 
@@ -21,7 +21,7 @@ class KillSubCommand(SubCommand):
             "-w", "--wait-time", dest="wait_time",
             help="Override the duration in seconds Storm waits between "
                  "deactivation and shutdown.")
-        add_nimbus_argument(parser)
+        add_nimbus_arguments(parser)
 
     def run(self, configs):
         kill_topology(configs)

--- a/pyleus/cli/commands/list_subcommand.py
+++ b/pyleus/cli/commands/list_subcommand.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from pyleus.cli.commands.subcommand import SubCommand
-from pyleus.cli.topologies import add_storm_cluster_ip_argument
+from pyleus.cli.topologies import add_nimbus_argument
 from pyleus.cli.topologies import list_topologies
 
 
@@ -14,7 +14,7 @@ class ListSubCommand(SubCommand):
     DESCRIPTION = "List all topologies running on a Storm cluster"
 
     def add_arguments(self, parser):
-        add_storm_cluster_ip_argument(parser)
+        add_nimbus_argument(parser)
 
     def run(self, configs):
         list_topologies(configs)

--- a/pyleus/cli/commands/list_subcommand.py
+++ b/pyleus/cli/commands/list_subcommand.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from pyleus.cli.commands.subcommand import SubCommand
-from pyleus.cli.topologies import add_nimbus_argument
+from pyleus.cli.topologies import add_nimbus_arguments
 from pyleus.cli.topologies import list_topologies
 
 
@@ -14,7 +14,7 @@ class ListSubCommand(SubCommand):
     DESCRIPTION = "List all topologies running on a Storm cluster"
 
     def add_arguments(self, parser):
-        add_nimbus_argument(parser)
+        add_nimbus_arguments(parser)
 
     def run(self, configs):
         list_topologies(configs)

--- a/pyleus/cli/commands/submit_subcommand.py
+++ b/pyleus/cli/commands/submit_subcommand.py
@@ -5,7 +5,7 @@ Args:
 """
 from __future__ import absolute_import
 
-from pyleus.cli.topologies import add_nimbus_argument
+from pyleus.cli.topologies import add_nimbus_arguments
 from pyleus.cli.topologies import submit_topology
 from pyleus.cli.commands.run_subcommand import RunSubCommand
 
@@ -17,7 +17,7 @@ class SubmitSubCommand(RunSubCommand):
     DESCRIPTION = "Submit a Pyleus topology to a Storm cluster"
 
     def add_specific_arguments(self, parser):
-        add_nimbus_argument(parser)
+        add_nimbus_arguments(parser)
 
     def run_topology(self, jar_path, configs):
         submit_topology(jar_path, configs)

--- a/pyleus/cli/commands/submit_subcommand.py
+++ b/pyleus/cli/commands/submit_subcommand.py
@@ -5,7 +5,7 @@ Args:
 """
 from __future__ import absolute_import
 
-from pyleus.cli.topologies import add_storm_cluster_ip_argument
+from pyleus.cli.topologies import add_nimbus_argument
 from pyleus.cli.topologies import submit_topology
 from pyleus.cli.commands.run_subcommand import RunSubCommand
 
@@ -17,7 +17,7 @@ class SubmitSubCommand(RunSubCommand):
     DESCRIPTION = "Submit a Pyleus topology to a Storm cluster"
 
     def add_specific_arguments(self, parser):
-        add_storm_cluster_ip_argument(parser)
+        add_nimbus_argument(parser)
 
     def run_topology(self, jar_path, configs):
         submit_topology(jar_path, configs)

--- a/pyleus/cli/storm_cluster.py
+++ b/pyleus/cli/storm_cluster.py
@@ -48,18 +48,19 @@ class StormCluster(object):
     """Object representing an interface to a Storm cluster.
     All the requests are basically translated into Storm commands.
     """
-    def __init__(self, storm_cmd_path, nimbus_ip, verbose, jvm_opts):
+
+    def __init__(self, storm_cmd_path, nimbus, verbose, jvm_opts):
         """Create the cluster object."""
 
         self.storm_cmd_path = storm_cmd_path
 
-        if nimbus_ip is None:
+        if nimbus is None:
             raise ConfigurationError(
                 "You must specify a storm cluster IP address."
                 " Use option <storm_cluster_ip> in the configuration file"
                 " or the command line option --storm-cluster")
 
-        self.nimbus_ip = nimbus_ip
+        self.nimbus = nimbus
         self.verbose = verbose
         self.jvm_opts = jvm_opts
 
@@ -73,7 +74,7 @@ class StormCluster(object):
 
         storm_cmd = [self.storm_cmd_path]
         storm_cmd += cmd
-        storm_cmd += ["-c", "nimbus.host={0}".format(self.nimbus_ip)]
+        storm_cmd += ["-c", "nimbus.host={0}".format(self.nimbus)]
 
         env = _get_storm_cmd_env(self.jvm_opts)
 

--- a/pyleus/cli/storm_cluster.py
+++ b/pyleus/cli/storm_cluster.py
@@ -56,9 +56,9 @@ class StormCluster(object):
 
         if nimbus is None:
             raise ConfigurationError(
-                "You must specify a storm cluster IP address."
-                " Use option <storm_cluster_ip> in the configuration file"
-                " or the command line option --storm-cluster")
+                "You must specify a Nimbus address. Use the option "
+                "<nimbus> in the configuration file or the command line "
+                "option -n/--nimbus.")
 
         self.nimbus = nimbus
         self.verbose = verbose

--- a/pyleus/cli/storm_cluster.py
+++ b/pyleus/cli/storm_cluster.py
@@ -49,32 +49,43 @@ class StormCluster(object):
     All the requests are basically translated into Storm commands.
     """
 
-    def __init__(self, storm_cmd_path, nimbus, verbose, jvm_opts):
+    def __init__(self, storm_cmd_path, nimbus_host, nimbus_port, verbose,
+                 jvm_opts):
         """Create the cluster object."""
 
         self.storm_cmd_path = storm_cmd_path
 
-        if nimbus is None:
+        if nimbus_host is None:
             raise ConfigurationError(
-                "You must specify a Nimbus address. Use the option "
-                "<nimbus> in the configuration file or the command line "
-                "option -n/--nimbus.")
+                "You must specify the Nimbus host. Use the option "
+                "<nimbus_host> in the configuration file or the command line "
+                "option -n/--nimbus-host.")
 
-        self.nimbus = nimbus
+        self.nimbus_host = nimbus_host
+        self.nimbus_port = nimbus_port
         self.verbose = verbose
         self.jvm_opts = jvm_opts
 
+    def _build_storm_cmd(self, cmd):
+        storm_cmd = [self.storm_cmd_path]
+        storm_cmd += cmd
+        storm_cmd += ["-c", "nimbus.host={0}".format(self.nimbus_host)]
+
+        if self.nimbus_port:
+            storm_cmd += ["-c", "nimbus.thrift.port={0}".format(
+                self.nimbus_port)]
+
+        return storm_cmd
+
     def _exec_storm_cmd(self, cmd, verbose=None):
         """Interface to any Storm command."""
+        storm_cmd = self._build_storm_cmd(cmd)
+
         out_stream = None
         if verbose is None:
             verbose = self.verbose
         if not verbose:
             out_stream = open(os.devnull, "w")
-
-        storm_cmd = [self.storm_cmd_path]
-        storm_cmd += cmd
-        storm_cmd += ["-c", "nimbus.host={0}".format(self.nimbus)]
 
         env = _get_storm_cmd_env(self.jvm_opts)
 

--- a/pyleus/cli/topologies.py
+++ b/pyleus/cli/topologies.py
@@ -8,12 +8,12 @@ from pyleus.cli.storm_cluster import LocalStormCluster
 from pyleus.cli.storm_cluster import StormCluster
 
 
-def add_storm_cluster_ip_argument(parser):
+def add_nimbus_argument(parser):
     """Add to the command parser an option in order to specify the cluster
     ip address from command line.
     """
     parser.add_argument(
-        "-n", "--nimbus", dest="storm_cluster_ip", metavar="NIMBUS",
+        "-n", "--nimbus", dest="nimbus", metavar="NIMBUS",
         help="The hostname or IP address of the Storm cluster's Nimbus node")
 
 
@@ -30,7 +30,7 @@ def submit_topology(jar_path, configs):
     """Submit the topology jar to the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.storm_cluster_ip,
+        configs.nimbus,
         configs.verbose,
         configs.jvm_opts).submit(jar_path)
 
@@ -39,7 +39,7 @@ def list_topologies(configs):
     """List the topologies running on the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.storm_cluster_ip,
+        configs.nimbus,
         configs.verbose,
         configs.jvm_opts).list()
 
@@ -48,7 +48,7 @@ def kill_topology(configs):
     """Kill a topology running on the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.storm_cluster_ip,
+        configs.nimbus,
         configs.verbose,
         configs.jvm_opts).kill(configs.topology_name, configs.wait_time)
 

--- a/pyleus/cli/topologies.py
+++ b/pyleus/cli/topologies.py
@@ -8,13 +8,14 @@ from pyleus.cli.storm_cluster import LocalStormCluster
 from pyleus.cli.storm_cluster import StormCluster
 
 
-def add_nimbus_argument(parser):
-    """Add to the command parser an option in order to specify the cluster
-    ip address from command line.
-    """
+def add_nimbus_arguments(parser):
+    """Add Nimbus host/port arguments to the command parser."""
     parser.add_argument(
-        "-n", "--nimbus", dest="nimbus", metavar="NIMBUS",
+        "-n", "--nimbus-host", dest="nimbus_host", metavar="NIMBUS_HOST",
         help="The hostname or IP address of the Storm cluster's Nimbus node")
+    parser.add_argument(
+        "-p", "--nimbus-port", dest="nimbus_port", metavar="NIMBUS_PORT",
+        help="The Thrift port used by the Storm cluster's Nimbus node")
 
 
 def run_topology_locally(jar_path, configs):
@@ -30,7 +31,8 @@ def submit_topology(jar_path, configs):
     """Submit the topology jar to the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.nimbus,
+        configs.nimbus_host,
+        configs.nimbus_port,
         configs.verbose,
         configs.jvm_opts).submit(jar_path)
 
@@ -39,7 +41,8 @@ def list_topologies(configs):
     """List the topologies running on the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.nimbus,
+        configs.nimbus_host,
+        configs.nimbus_port,
         configs.verbose,
         configs.jvm_opts).list()
 
@@ -48,7 +51,8 @@ def kill_topology(configs):
     """Kill a topology running on the Storm cluster specified in configs."""
     StormCluster(
         configs.storm_cmd_path,
-        configs.nimbus,
+        configs.nimbus_host,
+        configs.nimbus_port,
         configs.verbose,
         configs.jvm_opts).kill(configs.topology_name, configs.wait_time)
 

--- a/pyleus/configuration.py
+++ b/pyleus/configuration.py
@@ -26,7 +26,7 @@ invocations.
    storm_cmd_path: /usr/share/storm/bin/storm
 
    # optional: use -n option of pyleus CLI instead
-   nimbus: 10.11.12.13
+   nimbus_host: 10.11.12.13
 
    # java options to pass to Storm CLI
    jvm_opts: -Djava.io.tmpdir=/home/myuser/tmp
@@ -63,8 +63,9 @@ CONFIG_FILES_PATH = [
 Configuration = collections.namedtuple(
     "Configuration",
     "base_jar config_file debug func include_packages output_jar \
-     pypi_index_url nimbus storm_cmd_path system_site_packages topology_path \
-     topology_jar topology_name verbose wait_time jvm_opts"
+     pypi_index_url nimbus_host nimbus_port storm_cmd_path \
+     system_site_packages topology_path topology_jar topology_name verbose \
+     wait_time jvm_opts"
 )
 """Namedtuple containing all pyleus configuration values."""
 
@@ -77,7 +78,8 @@ DEFAULTS = Configuration(
     include_packages=None,
     output_jar=None,
     pypi_index_url=None,
-    nimbus=None,
+    nimbus_host=None,
+    nimbus_port=None,
     storm_cmd_path=None,
     system_site_packages=False,
     topology_path="pyleus_topology.yaml",

--- a/pyleus/configuration.py
+++ b/pyleus/configuration.py
@@ -26,7 +26,7 @@ invocations.
    storm_cmd_path: /usr/share/storm/bin/storm
 
    # optional: use -n option of pyleus CLI instead
-   nimbus_ip: 10.11.12.13
+   nimbus: 10.11.12.13
 
    # java options to pass to Storm CLI
    jvm_opts: -Djava.io.tmpdir=/home/myuser/tmp
@@ -63,8 +63,8 @@ CONFIG_FILES_PATH = [
 Configuration = collections.namedtuple(
     "Configuration",
     "base_jar config_file debug func include_packages output_jar \
-     pypi_index_url storm_cluster_ip storm_cmd_path system_site_packages \
-     topology_path topology_jar topology_name verbose wait_time jvm_opts"
+     pypi_index_url nimbus storm_cmd_path system_site_packages topology_path \
+     topology_jar topology_name verbose wait_time jvm_opts"
 )
 """Namedtuple containing all pyleus configuration values."""
 
@@ -77,7 +77,7 @@ DEFAULTS = Configuration(
     include_packages=None,
     output_jar=None,
     pypi_index_url=None,
-    storm_cluster_ip=None,
+    nimbus=None,
     storm_cmd_path=None,
     system_site_packages=False,
     topology_path="pyleus_topology.yaml",

--- a/pyleus/configuration.py
+++ b/pyleus/configuration.py
@@ -28,6 +28,9 @@ invocations.
    # optional: use -n option of pyleus CLI instead
    nimbus_host: 10.11.12.13
 
+   # optional: use -p option of pyleus CLI instead
+   nimbus_port: 6628
+
    # java options to pass to Storm CLI
    jvm_opts: -Djava.io.tmpdir=/home/myuser/tmp
 

--- a/tests/cli/storm_cluster_test.py
+++ b/tests/cli/storm_cluster_test.py
@@ -1,8 +1,13 @@
 import os
 
+import mock
+from mock import sentinel
 import pytest
 
-from pyleus.cli.storm_cluster import _get_storm_cmd_env, STORM_JAR_JVM_OPTS
+from pyleus.cli.storm_cluster import _get_storm_cmd_env
+from pyleus.cli.storm_cluster import STORM_JAR_JVM_OPTS
+from pyleus.cli.storm_cluster import StormCluster
+from pyleus.cli.storm_cluster import TOPOLOGY_BUILDER_CLASS
 
 
 class TestGetStormCmdEnd(object):
@@ -18,3 +23,37 @@ class TestGetStormCmdEnd(object):
         jvm_opts = "-Dfoo=bar"
         env = _get_storm_cmd_env(jvm_opts)
         assert env[STORM_JAR_JVM_OPTS] == jvm_opts
+
+
+class TestStormCluster(object):
+
+    @pytest.fixture
+    def cluster(self):
+        return StormCluster(
+            sentinel.storm_cmd_path,
+            sentinel.nimbus_host,
+            sentinel.nimbus_port,
+            sentinel.verbose,
+            sentinel.jvm_opts,
+        )
+
+    def test__build_storm_cmd_no_port(self, cluster):
+        cluster.nimbus_host = "test-host"
+        cluster.nimbus_port = None
+        storm_cmd = cluster._build_storm_cmd(["a", "cmd"])
+        assert storm_cmd == [sentinel.storm_cmd_path, "a", "cmd", "-c",
+                             "nimbus.host=test-host"]
+
+    def test__build_storm_cmd_with_port(self, cluster):
+        cluster.nimbus_host = "test-host"
+        cluster.nimbus_port = 4321
+        storm_cmd = cluster._build_storm_cmd(["another", "cmd"])
+        assert storm_cmd == [sentinel.storm_cmd_path, "another", "cmd", "-c",
+                             "nimbus.host=test-host", "-c",
+                             "nimbus.thrift.port=4321"]
+
+    def test_submit(self, cluster):
+        with mock.patch.object(cluster, '_exec_storm_cmd') as mock_exec:
+            cluster.submit(sentinel.jar_path)
+
+        mock_exec.assert_called_once_with(["jar", sentinel.jar_path, TOPOLOGY_BUILDER_CLASS])

--- a/tests/cli/topologies_test.py
+++ b/tests/cli/topologies_test.py
@@ -1,0 +1,81 @@
+import mock
+from mock import sentinel
+import pytest
+
+from pyleus.configuration import Configuration, DEFAULTS
+import pyleus.cli.topologies
+from pyleus.cli.topologies import kill_topology
+from pyleus.cli.topologies import list_topologies
+from pyleus.cli.topologies import submit_topology
+
+
+@pytest.fixture
+def configs():
+    """Create a mock Configuration object with sentinel values
+
+    Eg.
+
+        Configuration(
+            base_jar=sentinel.base_jar,
+            config_file=sentinel.config_file,
+            ...
+        )
+    """
+    return Configuration(**dict(
+        (k, getattr(sentinel, k))
+        for k in DEFAULTS._asdict().keys()
+    ))
+
+
+def test_submit_topology(configs):
+    mock_storm_cluster = mock.Mock()
+
+    with mock.patch.object(pyleus.cli.topologies, 'StormCluster',
+            return_value=mock_storm_cluster) as mock_ctr:
+        submit_topology(sentinel.jar_path, configs)
+
+    mock_ctr.assert_called_once_with(
+        configs.storm_cmd_path,
+        configs.nimbus_host,
+        configs.nimbus_port,
+        configs.verbose,
+        configs.jvm_opts,
+    )
+
+    mock_storm_cluster.submit.assert_called_once_with(sentinel.jar_path)
+
+
+def test_kill_topology(configs):
+    mock_storm_cluster = mock.Mock()
+
+    with mock.patch.object(pyleus.cli.topologies, 'StormCluster',
+            return_value=mock_storm_cluster) as mock_ctr:
+        kill_topology(configs)
+
+    mock_ctr.assert_called_once_with(
+        configs.storm_cmd_path,
+        configs.nimbus_host,
+        configs.nimbus_port,
+        configs.verbose,
+        configs.jvm_opts,
+    )
+
+    mock_storm_cluster.kill.assert_called_once_with(configs.topology_name, configs.wait_time)
+
+
+def test_list_topologies(configs):
+    mock_storm_cluster = mock.Mock()
+
+    with mock.patch.object(pyleus.cli.topologies, 'StormCluster',
+            return_value=mock_storm_cluster) as mock_ctr:
+        list_topologies(configs)
+
+    mock_ctr.assert_called_once_with(
+        configs.storm_cmd_path,
+        configs.nimbus_host,
+        configs.nimbus_port,
+        configs.verbose,
+        configs.jvm_opts,
+    )
+
+    mock_storm_cluster.list.assert_called_once_with()


### PR DESCRIPTION
This expands upon #32, so I will close that PR.

In summary, this change:
- Renames `-n/--nimbus-ip/nimbus_ip/NIMBUS_IP` to `-n/--nimbus-host/nimbus_host/NIMBUS_HOST`
- Adds `-p/--nimbus-port/nimbus_port/NIMBUS_PORT`
- Adds some tests of this and other behavior surrounding config vars
