### PR TITLE
Miscellaneous Python 3 compatibility fixes

### DIFF
--- a/pyleus/_base_jar.py
+++ b/pyleus/_base_jar.py
@@ -7,4 +7,4 @@ from __future__ import absolute_import
 import pyleus
 
 if __name__ == '__main__':
-    print pyleus.BASE_JAR_PATH
+    print(pyleus.BASE_JAR_PATH)

--- a/pyleus/cli/build.py
+++ b/pyleus/cli/build.py
@@ -5,7 +5,6 @@ object. The caller function should handle PyleusError exceptions.
 """
 from __future__ import absolute_import
 
-from cStringIO import StringIO
 import glob
 import re
 import tempfile
@@ -17,6 +16,7 @@ import zipfile
 from pyleus import __version__
 from pyleus.cli.topology_spec import TopologySpec
 from pyleus.cli.virtualenv_proxy import VirtualenvProxy
+from pyleus.compat import StringIO
 from pyleus.storm.component import DESCRIBE_OPT
 from pyleus.exception import InvalidTopologyError
 from pyleus.exception import JarError

--- a/pyleus/compat.py
+++ b/pyleus/compat.py
@@ -1,0 +1,11 @@
+import sys
+
+if sys.version_info.major < 3:
+    from cStringIO import StringIO
+    BytesIO = StringIO
+else:
+    from io import BytesIO
+    from io import StringIO
+
+_ = BytesIO
+_ = StringIO

--- a/pyleus/compat.py
+++ b/pyleus/compat.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
     from cStringIO import StringIO
     BytesIO = StringIO
 else:

--- a/pyleus/compat.py
+++ b/pyleus/compat.py
@@ -7,5 +7,5 @@ else:
     from io import BytesIO
     from io import StringIO
 
-_ = BytesIO
-_ = StringIO
+_ = BytesIO  # pyflakes
+_ = StringIO  # pyflakes

--- a/pyleus/storm/component.py
+++ b/pyleus/storm/component.py
@@ -158,10 +158,10 @@ class Component(object):
         cofiguration and validation.
         """
 
-        print json.dumps({
+        print(json.dumps({
             "component_type": self.COMPONENT_TYPE,
             "output_fields": _expand_output_fields(self.OUTPUT_FIELDS),
-            "options": _serialize(self.OPTIONS)})
+            "options": _serialize(self.OPTIONS)}))
 
     def initialize_logging(self):
         """Load logging configuration file from command line configuration (if

--- a/tests/storm/serializers/json_serializer_test.py
+++ b/tests/storm/serializers/json_serializer_test.py
@@ -1,4 +1,3 @@
-from cStringIO import StringIO
 import mock
 
 try:
@@ -7,6 +6,7 @@ try:
 except ImportError:
     import json
 
+from pyleus.compat import StringIO
 from pyleus.storm.serializers.json_serializer import JSONSerializer
 from testing.serializer import SerializerTestCase
 

--- a/tests/storm/serializers/msgpack_serializer_test.py
+++ b/tests/storm/serializers/msgpack_serializer_test.py
@@ -1,9 +1,9 @@
-from cStringIO import StringIO
 import mock
 import os
 
 import msgpack
 
+from pyleus.compat import BytesIO
 from pyleus.storm.serializers.msgpack_serializer import MsgpackSerializer
 from testing.serializer import SerializerTestCase
 
@@ -14,7 +14,7 @@ class TestMsgpackSerializer(SerializerTestCase):
 
     def test_read_msg_dict(self):
         msg_dict = {
-            'hello': "world",
+            b'hello': b"world",
         }
 
         encoded_msg = msgpack.packb(msg_dict)
@@ -42,7 +42,7 @@ class TestMsgpackSerializer(SerializerTestCase):
         expected_output = msgpack.packb(msg_dict)
 
         with mock.patch.object(
-                self.instance, '_output_stream', StringIO()) as sio:
+                self.instance, '_output_stream', BytesIO()) as sio:
             self.instance.send_msg(msg_dict)
 
         assert sio.getvalue() == expected_output


### PR DESCRIPTION
This takes care of the "print-function" and "StringIO" Python 3 incompatibilities.

I imagine the "contextlib.nested" ones are going to be pretty annoying, and I have no clue about the "**module**" errors.

(You can run the tests under Python 3 with `$ TOXENV=py34 tox`)
