### PR TITLE
Section about Storm dependency in install doc page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@ Pyleus v\ |version|
 Pyleus is a Python 2.6+ layer built on top of `Apache Storm`_ for building Storm topologies in idiomatic Python.
 
 * Pyleus is available on PyPI: https://pypi.python.org/pypi/pyleus
-* The source is hosted on github: https://github.com/Yelp/pyleus
+* The source is hosted on GitHub: https://github.com/Yelp/pyleus
 
 .. warning::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,3 +12,21 @@ You can install pyleus from PyPI either system-wide or in a virtualenv:
 .. note::
 
    You do **NOT**  need to install pyleus on your Storm cluster.
+
+.. warning::
+
+   Installing Pyleus from source is **NOT** recommended. Please refer to section :ref:`development_tips` for more info.
+
+Specify your Storm path
+-----------------------
+
+Pyleus will automatically look for the ``storm`` executable in your ``$PATH`` when executing a command.
+
+If you do not have Apache Storm already installed on your machine, you will need to download and extract Storm 0.9.2-incubating—the current release—from https://storm.apache.org/downloads.html.
+
+After that, create a config file ``~/.pyleus.conf`` so Pyleus can find the ``storm`` command:
+
+.. code-block:: ini
+
+   [storm]
+   storm_cmd_path: /path/to/apache-storm-0.9.2-incubating/bin/storm

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -17,6 +17,8 @@ You can install pyleus from PyPI either system-wide or in a virtualenv:
 
    Installing Pyleus from source is **NOT** recommended. Please refer to section :ref:`development_tips` for more info.
 
+   The **recommended** way to install Pyleus is ``pip install pyleus`` either system-wide or in a virtualenv.
+
 Specify your Storm path
 -----------------------
 


### PR DESCRIPTION
I believe that what included in the Quick Start section should be repeated also here.

Link to section "development_tips" will be fixed when by the Contributing page coming soon.
