### PR TITLE
Depend on simplejson for Python < 2.7

### DIFF
--- a/examples/top_urls/requirements.txt
+++ b/examples/top_urls/requirements.txt
@@ -1,1 +1,0 @@
-simplejson

--- a/examples/top_urls/top_urls/requests_generator.py
+++ b/examples/top_urls/top_urls/requests_generator.py
@@ -5,12 +5,7 @@ import logging
 from random import choice
 import time
 
-try:
-    import simplejson as json
-    _ = json # pyflakes
-except ImportError:
-    import json
-
+from pyleus.compat import json
 from pyleus.storm import Spout
 
 

--- a/pyleus/compat.py
+++ b/pyleus/compat.py
@@ -1,6 +1,8 @@
 import sys
 
-if sys.version_info[0] < 3:
+python_version = (sys.version_info[0], sys.version_info[1])
+
+if python_version < (3, 0):
     from cStringIO import StringIO
     BytesIO = StringIO
 else:
@@ -9,3 +11,10 @@ else:
 
 _ = BytesIO  # pyflakes
 _ = StringIO  # pyflakes
+
+if python_version < (2, 7):
+    import simplejson as json
+else:
+    import json
+
+_ = json  # pyflakes

--- a/pyleus/json_fields_bolt.py
+++ b/pyleus/json_fields_bolt.py
@@ -3,13 +3,8 @@ from __future__ import absolute_import
 
 import logging
 
-try:
-    import simplejson as json
-    _ = json # pyflakes
-except ImportError:
-    import json
-
-from .storm import SimpleBolt
+from pyleus.compat import json
+from pyleus.storm import SimpleBolt
 
 log = logging.getLogger(__name__)
 

--- a/pyleus/storm/component.py
+++ b/pyleus/storm/component.py
@@ -11,12 +11,7 @@ import os
 import sys
 import traceback
 
-try:
-    import simplejson as json
-    _ = json # pyflakes
-except ImportError:
-    import json
-
+from pyleus.compat import json
 from pyleus.storm import DEFAULT_STREAM
 from pyleus.storm import StormTuple
 from pyleus.storm.serializers.msgpack_serializer import MsgpackSerializer

--- a/pyleus/storm/serializers/json_serializer.py
+++ b/pyleus/storm/serializers/json_serializer.py
@@ -1,11 +1,6 @@
 """JSON implementation of Pyleus serializer"""
 
-try:
-    import simplejson as json
-    _ = json # pyflakes
-except ImportError:
-    import json
-
+from pyleus.compat import json
 from pyleus.storm import StormWentAwayError
 from pyleus.storm.serializers.serializer import Serializer
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,10 @@ if sys.version_info < (2, 7):
     # argparse is in the standard library of Python >= 2.7
     extra_install_requires.append("argparse")
 
+    # simplejson has better beformance in Python < 2.6 than the built-in json
+    # module
+    extra_install_requires.append("simplejson")
+
 
 setup(
     name="pyleus",

--- a/tests/storm/serializers/json_serializer_test.py
+++ b/tests/storm/serializers/json_serializer_test.py
@@ -1,11 +1,6 @@
 import mock
 
-try:
-    import simplejson as json
-    _ = json # pyflakes
-except ImportError:
-    import json
-
+from pyleus.compat import json
 from pyleus.compat import StringIO
 from pyleus.storm.serializers.json_serializer import JSONSerializer
 from testing.serializer import SerializerTestCase


### PR DESCRIPTION
This adds a dependency on simplejson for Python < 2.7 and moves the
stanza to import the appropriate json module into pyleus.compat.

Closes #46
