### PR TITLE
Fix msgpack long value in java serializer

### DIFF
--- a/topology_builder/src/main/java/com/yelp/pyleus/serializer/MessagePackSerializer.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/serializer/MessagePackSerializer.java
@@ -144,7 +144,7 @@ public class MessagePackSerializer implements ISerializer {
             case RAW:
                 return element.asRawValue().getString();
             case INTEGER:
-                return element.asIntegerValue().getInt();
+                return element.asIntegerValue().getLong();
             case FLOAT:
                 return element.asFloatValue().getFloat();
             case BOOLEAN:


### PR DESCRIPTION
msgpack serializer in the java code breaks if the serialized value is represented as java long instead of java int. We can't distinguish between long and int in msgpack, so using always getLong() is the safest solution. This does not have any effect in python, but protects from java failures. 
