### PR TITLE
Added support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 env:
     - TOXENV=py26
     - TOXENV=py27
-    - TOXENV=py31
     - TOXENV=py32
     - TOXENV=py33
     - TOXENV=py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 env:
     - TOXENV=py26
     - TOXENV=py27
+    - TOXENV=py31
+    - TOXENV=py32
+    - TOXENV=py33
+    - TOXENV=py34
 
 install:
     - pip install tox

--- a/examples/micro/micro/rates_generator.py
+++ b/examples/micro/micro/rates_generator.py
@@ -19,7 +19,7 @@ class RatesGeneratorSpout(Spout):
 
     def next_tuple(self):
         time.sleep(0.1)
-        currency = random.choice(BASE.keys())
+        currency = random.choice(list(BASE.keys()))
         rate = BASE[currency] + random.uniform(-RANGE, RANGE)
         log.debug("{0} {1}".format(currency, rate))
         self.emit((currency, rate,))

--- a/pyleus/cli/topology_spec.py
+++ b/pyleus/cli/topology_spec.py
@@ -201,7 +201,7 @@ class BoltSpec(ComponentSpec):
                 " one type. Found: {1}"
                 .format(self.name, group.keys()))
 
-        group_type = group.keys()[0]
+        group_type = list(group.keys())[0]
 
         if (group_type not in self.GROUPINGS_LIST):
             raise InvalidTopologyError(
@@ -285,7 +285,7 @@ class BoltSpec(ComponentSpec):
         component match with all the other specs.
         """
         for group in self.groupings:
-            group_type = group.keys()[0]
+            group_type = list(group.keys())[0]
             group_spec = group[group_type]
 
             self._verify_grouping_format(group_type, group_spec)

--- a/pyleus/compat.py
+++ b/pyleus/compat.py
@@ -1,11 +1,11 @@
-import sys
 
-if sys.version_info[0] < 3:
-    from cStringIO import StringIO
-    BytesIO = StringIO
-else:
-    from io import BytesIO
-    from io import StringIO
+try:
+    # In python 3.3+ mock got included in the standard library...
+    from unittest import mock
+except ImportError:
+    import mock
 
-_ = BytesIO  # pyflakes
-_ = StringIO  # pyflakes
+from six.moves import builtins, configparser, cStringIO as StringIO
+from six import BytesIO
+
+assert mock and builtins and configparser and StringIO and BytesIO

--- a/pyleus/compat.py
+++ b/pyleus/compat.py
@@ -1,4 +1,4 @@
-from six.moves import builtins, configparser, cStringIO as StringIO
+from six.moves import configparser, cStringIO as StringIO
 from six import BytesIO
 
-assert builtins and configparser and StringIO and BytesIO
+assert configparser and StringIO and BytesIO  # pyflakes

--- a/pyleus/compat.py
+++ b/pyleus/compat.py
@@ -1,11 +1,4 @@
-
-try:
-    # In python 3.3+ mock got included in the standard library...
-    from unittest import mock
-except ImportError:
-    import mock
-
 from six.moves import builtins, configparser, cStringIO as StringIO
 from six import BytesIO
 
-assert mock and builtins and configparser and StringIO and BytesIO
+assert builtins and configparser and StringIO and BytesIO

--- a/pyleus/configuration.py
+++ b/pyleus/configuration.py
@@ -47,12 +47,12 @@ invocations.
 from __future__ import absolute_import
 
 import collections
-import ConfigParser
 import os
 
 from pyleus import BASE_JAR_PATH
 from pyleus.utils import expand_path
 from pyleus.exception import ConfigurationError
+from pyleus.compat import configparser
 
 
 # Configuration files paths in order of increasing precedence
@@ -129,7 +129,7 @@ def load_configuration(cmd_line_file):
         _validate_config_file(cmd_line_file)
         config_files_hierarchy.append(cmd_line_file)
 
-    config = ConfigParser.SafeConfigParser()
+    config = configparser.SafeConfigParser()
     config.read(config_files_hierarchy)
 
     configs = update_configuration(

--- a/pyleus/testing.py
+++ b/pyleus/testing.py
@@ -3,7 +3,12 @@ from __future__ import absolute_import
 
 import pytest
 
-from pyleus.compat import mock
+try:
+    # In python 3.3+ mock got included in the standard library...
+    from unittest import mock
+except ImportError:
+    import mock
+
 from pyleus.storm.component import Component
 
 

--- a/pyleus/testing.py
+++ b/pyleus/testing.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import pytest
+from six.moves import builtins
 
 try:
     # In python 3.3+ mock got included in the standard library...
@@ -26,3 +27,5 @@ class ComponentTestCase(object):
             input_stream=self.mock_input_stream,
             output_stream=self.mock_output_stream,
         )
+
+assert builtins  # pyflakes

--- a/pyleus/testing.py
+++ b/pyleus/testing.py
@@ -1,9 +1,9 @@
 """Helper functions and classes for testing."""
 from __future__ import absolute_import
 
-import mock
 import pytest
 
+from pyleus.compat import mock
 from pyleus.storm.component import Component
 
 

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
         "PyYAML",
         "msgpack-python",
         "virtualenv",
+        "six",
     ] + extra_install_requires,
     package_data={'pyleus': [BASE_JAR]},
     cmdclass={

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pyflakes
 pytest
 mock
+six

--- a/testing/serializer.py
+++ b/testing/serializer.py
@@ -1,6 +1,6 @@
-import mock
 import pytest
 
+from pyleus.compat import mock
 from pyleus.storm.serializers.serializer import Serializer
 
 

--- a/testing/serializer.py
+++ b/testing/serializer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pyleus.compat import mock
+from pyleus.testing import mock
 from pyleus.storm.serializers.serializer import Serializer
 
 

--- a/tests/cli/build_test.py
+++ b/tests/cli/build_test.py
@@ -3,12 +3,12 @@ import os
 import shutil
 import zipfile
 
-import mock
 import pytest
 
 from pyleus import __version__
 from pyleus import exception
 from pyleus.cli import build
+from pyleus.testing import mock
 
 
 class TestBuild(object):

--- a/tests/cli/commands/subcommand_test.py
+++ b/tests/cli/commands/subcommand_test.py
@@ -1,11 +1,9 @@
-import __builtin__
-
-import mock
 import pytest
 
 from pyleus.cli.commands import subcommand
 from pyleus.cli.commands.subcommand import SubCommand
 from pyleus.exception import ConfigurationError
+from pyleus.compat import mock, builtins
 
 
 class TestSubCommand(object):
@@ -29,7 +27,7 @@ class TestSubCommand(object):
     @mock.patch.object(
         subcommand, "_ensure_storm_path_in_configs", autospec=True)
     @mock.patch.object(subcommand, "update_configuration", autospec=True)
-    @mock.patch.object(__builtin__, "vars", autospec=True)
+    @mock.patch.object(builtins, "vars", autospec=True)
     @mock.patch.object(SubCommand, "run")
     def test_run_subcommand(
             self, mock_run, mock_vars, mock_update, mock_ensure, mock_load,

--- a/tests/cli/commands/subcommand_test.py
+++ b/tests/cli/commands/subcommand_test.py
@@ -3,8 +3,7 @@ import pytest
 from pyleus.cli.commands import subcommand
 from pyleus.cli.commands.subcommand import SubCommand
 from pyleus.exception import ConfigurationError
-from pyleus.compat import builtins
-from pyleus.testing import mock
+from pyleus.testing import mock, builtins
 
 
 class TestSubCommand(object):

--- a/tests/cli/commands/subcommand_test.py
+++ b/tests/cli/commands/subcommand_test.py
@@ -3,7 +3,8 @@ import pytest
 from pyleus.cli.commands import subcommand
 from pyleus.cli.commands.subcommand import SubCommand
 from pyleus.exception import ConfigurationError
-from pyleus.compat import mock, builtins
+from pyleus.compat import builtins
+from pyleus.testing import mock
 
 
 class TestSubCommand(object):

--- a/tests/cli/storm_cluster_test.py
+++ b/tests/cli/storm_cluster_test.py
@@ -6,7 +6,7 @@ from pyleus.cli.storm_cluster import _get_storm_cmd_env
 from pyleus.cli.storm_cluster import STORM_JAR_JVM_OPTS
 from pyleus.cli.storm_cluster import StormCluster
 from pyleus.cli.storm_cluster import TOPOLOGY_BUILDER_CLASS
-from pyleus.compat import mock
+from pyleus.testing import mock
 
 
 class TestGetStormCmdEnd(object):

--- a/tests/cli/storm_cluster_test.py
+++ b/tests/cli/storm_cluster_test.py
@@ -1,13 +1,12 @@
 import os
 
-import mock
-from mock import sentinel
 import pytest
 
 from pyleus.cli.storm_cluster import _get_storm_cmd_env
 from pyleus.cli.storm_cluster import STORM_JAR_JVM_OPTS
 from pyleus.cli.storm_cluster import StormCluster
 from pyleus.cli.storm_cluster import TOPOLOGY_BUILDER_CLASS
+from pyleus.compat import mock
 
 
 class TestGetStormCmdEnd(object):
@@ -30,30 +29,30 @@ class TestStormCluster(object):
     @pytest.fixture
     def cluster(self):
         return StormCluster(
-            sentinel.storm_cmd_path,
-            sentinel.nimbus_host,
-            sentinel.nimbus_port,
-            sentinel.verbose,
-            sentinel.jvm_opts,
+            mock.sentinel.storm_cmd_path,
+            mock.sentinel.nimbus_host,
+            mock.sentinel.nimbus_port,
+            mock.sentinel.verbose,
+            mock.sentinel.jvm_opts,
         )
 
     def test__build_storm_cmd_no_port(self, cluster):
         cluster.nimbus_host = "test-host"
         cluster.nimbus_port = None
         storm_cmd = cluster._build_storm_cmd(["a", "cmd"])
-        assert storm_cmd == [sentinel.storm_cmd_path, "a", "cmd", "-c",
+        assert storm_cmd == [mock.sentinel.storm_cmd_path, "a", "cmd", "-c",
                              "nimbus.host=test-host"]
 
     def test__build_storm_cmd_with_port(self, cluster):
         cluster.nimbus_host = "test-host"
         cluster.nimbus_port = 4321
         storm_cmd = cluster._build_storm_cmd(["another", "cmd"])
-        assert storm_cmd == [sentinel.storm_cmd_path, "another", "cmd", "-c",
+        assert storm_cmd == [mock.sentinel.storm_cmd_path, "another", "cmd", "-c",
                              "nimbus.host=test-host", "-c",
                              "nimbus.thrift.port=4321"]
 
     def test_submit(self, cluster):
         with mock.patch.object(cluster, '_exec_storm_cmd') as mock_exec:
-            cluster.submit(sentinel.jar_path)
+            cluster.submit(mock.sentinel.jar_path)
 
-        mock_exec.assert_called_once_with(["jar", sentinel.jar_path, TOPOLOGY_BUILDER_CLASS])
+        mock_exec.assert_called_once_with(["jar", mock.sentinel.jar_path, TOPOLOGY_BUILDER_CLASS])

--- a/tests/cli/topologies_test.py
+++ b/tests/cli/topologies_test.py
@@ -1,5 +1,3 @@
-import mock
-from mock import sentinel
 import pytest
 
 from pyleus.configuration import Configuration, DEFAULTS
@@ -7,22 +5,23 @@ import pyleus.cli.topologies
 from pyleus.cli.topologies import kill_topology
 from pyleus.cli.topologies import list_topologies
 from pyleus.cli.topologies import submit_topology
+from pyleus.compat import mock
 
 
 @pytest.fixture
 def configs():
-    """Create a mock Configuration object with sentinel values
+    """Create a mock Configuration object with mock.sentinel values
 
     Eg.
 
         Configuration(
-            base_jar=sentinel.base_jar,
-            config_file=sentinel.config_file,
+            base_jar=mock.sentinel.base_jar,
+            config_file=mock.sentinel.config_file,
             ...
         )
     """
     return Configuration(**dict(
-        (k, getattr(sentinel, k))
+        (k, getattr(mock.sentinel, k))
         for k in DEFAULTS._asdict().keys()
     ))
 
@@ -32,7 +31,7 @@ def test_submit_topology(configs):
 
     with mock.patch.object(pyleus.cli.topologies, 'StormCluster',
             return_value=mock_storm_cluster) as mock_ctr:
-        submit_topology(sentinel.jar_path, configs)
+        submit_topology(mock.sentinel.jar_path, configs)
 
     mock_ctr.assert_called_once_with(
         configs.storm_cmd_path,
@@ -42,7 +41,7 @@ def test_submit_topology(configs):
         configs.jvm_opts,
     )
 
-    mock_storm_cluster.submit.assert_called_once_with(sentinel.jar_path)
+    mock_storm_cluster.submit.assert_called_once_with(mock.sentinel.jar_path)
 
 
 def test_kill_topology(configs):

--- a/tests/cli/topologies_test.py
+++ b/tests/cli/topologies_test.py
@@ -5,7 +5,7 @@ import pyleus.cli.topologies
 from pyleus.cli.topologies import kill_topology
 from pyleus.cli.topologies import list_topologies
 from pyleus.cli.topologies import submit_topology
-from pyleus.compat import mock
+from pyleus.testing import mock
 
 
 @pytest.fixture

--- a/tests/cli/virtualenv_proxy_test.py
+++ b/tests/cli/virtualenv_proxy_test.py
@@ -6,8 +6,7 @@ import pytest
 from pyleus import exception
 from pyleus.cli import virtualenv_proxy
 from pyleus.cli.virtualenv_proxy import VirtualenvProxy
-from pyleus.compat import builtins
-from pyleus.testing import mock
+from pyleus.testing import mock, builtins
 
 
 VENV_PATH = "/tmp/my/beloved/venv"

--- a/tests/cli/virtualenv_proxy_test.py
+++ b/tests/cli/virtualenv_proxy_test.py
@@ -1,13 +1,12 @@
-import __builtin__
 import os
 import subprocess
 
-import mock
 import pytest
 
 from pyleus import exception
 from pyleus.cli import virtualenv_proxy
 from pyleus.cli.virtualenv_proxy import VirtualenvProxy
+from pyleus.compat import mock, builtins
 
 
 VENV_PATH = "/tmp/my/beloved/venv"
@@ -38,7 +37,7 @@ class TestVirtualenvProxyTopLevelFunctions(object):
 
 class TestVirtualenvProxyCreation(object):
 
-    @mock.patch.object(__builtin__, 'open', autospec=True)
+    @mock.patch.object(builtins, 'open', autospec=True)
     @mock.patch.object(VirtualenvProxy, '_create_virtualenv', autospec=True)
     def test___init__(self, mock_create, mock_open):
         mock_open.return_value = 42
@@ -51,7 +50,7 @@ class TestVirtualenvProxyCreation(object):
         assert mock_open.call_count == 1
         assert venv._out_stream is None
 
-    @mock.patch.object(__builtin__, 'open', autospec=True)
+    @mock.patch.object(builtins, 'open', autospec=True)
     @mock.patch.object(virtualenv_proxy, '_exec_shell_cmd', autospec=True)
     def test__create_virtualenv_system_site_packages(
             self, mock_cmd, mock_open):
@@ -65,7 +64,7 @@ class TestVirtualenvProxyCreation(object):
             err_msg=mock.ANY
         )
 
-    @mock.patch.object(__builtin__, 'open', autospec=True)
+    @mock.patch.object(builtins, 'open', autospec=True)
     @mock.patch.object(virtualenv_proxy, '_exec_shell_cmd', autospec=True)
     def test__create_virtualenv_no_system_site_packages(
             self, mock_cmd, mock_open):
@@ -83,7 +82,7 @@ class TestVirtualenvProxyCreation(object):
 class TestVirtualenvProxyMethods(object):
 
     @pytest.fixture(autouse=True)
-    @mock.patch.object(__builtin__, 'open', autospec=True)
+    @mock.patch.object(builtins, 'open', autospec=True)
     @mock.patch.object(VirtualenvProxy, '_create_virtualenv', autospec=True)
     def setup_virtualenv(self, mock_create, mock_open):
         self.venv = VirtualenvProxy(VENV_PATH,

--- a/tests/cli/virtualenv_proxy_test.py
+++ b/tests/cli/virtualenv_proxy_test.py
@@ -6,7 +6,8 @@ import pytest
 from pyleus import exception
 from pyleus.cli import virtualenv_proxy
 from pyleus.cli.virtualenv_proxy import VirtualenvProxy
-from pyleus.compat import mock, builtins
+from pyleus.compat import builtins
+from pyleus.testing import mock
 
 
 VENV_PATH = "/tmp/my/beloved/venv"

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from pyleus import configuration
 from pyleus import exception
-from pyleus.compat import mock
+from pyleus.testing import mock
 
 
 class TestConfiguration(object):

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -1,10 +1,10 @@
 import os
 
-import mock
 import pytest
 
 from pyleus import configuration
 from pyleus import exception
+from pyleus.compat import mock
 
 
 class TestConfiguration(object):

--- a/tests/json_fields_bolt_test.py
+++ b/tests/json_fields_bolt_test.py
@@ -1,8 +1,8 @@
-import mock
 import pytest
 
 from pyleus.json_fields_bolt import JSONFieldsBolt
 from pyleus.testing import ComponentTestCase
+from pyleus.compat import mock
 
 
 class TestJSONFieldsBolt(ComponentTestCase):

--- a/tests/json_fields_bolt_test.py
+++ b/tests/json_fields_bolt_test.py
@@ -1,8 +1,7 @@
 import pytest
 
 from pyleus.json_fields_bolt import JSONFieldsBolt
-from pyleus.testing import ComponentTestCase
-from pyleus.compat import mock
+from pyleus.testing import ComponentTestCase, mock
 
 
 class TestJSONFieldsBolt(ComponentTestCase):

--- a/tests/storm/bolt_test.py
+++ b/tests/storm/bolt_test.py
@@ -3,9 +3,8 @@ import contextlib
 
 import pytest
 
-from pyleus.compat import mock
 from pyleus.storm import StormTuple, Bolt, SimpleBolt
-from pyleus.testing import ComponentTestCase
+from pyleus.testing import ComponentTestCase, mock
 
 
 class TestBolt(ComponentTestCase):

--- a/tests/storm/component_test.py
+++ b/tests/storm/component_test.py
@@ -4,8 +4,8 @@ import os.path
 from pyleus.storm import StormTuple
 from pyleus.storm.component import DEFAULT_LOGGING_CONFIG_PATH
 from pyleus.storm.serializers.serializer import Serializer
-from pyleus.testing import ComponentTestCase
-from pyleus.compat import mock, builtins
+from pyleus.testing import ComponentTestCase, mock
+from pyleus.compat import builtins
 
 
 class TestComponent(ComponentTestCase):

--- a/tests/storm/component_test.py
+++ b/tests/storm/component_test.py
@@ -4,8 +4,7 @@ import os.path
 from pyleus.storm import StormTuple
 from pyleus.storm.component import DEFAULT_LOGGING_CONFIG_PATH
 from pyleus.storm.serializers.serializer import Serializer
-from pyleus.testing import ComponentTestCase, mock
-from pyleus.compat import builtins
+from pyleus.testing import ComponentTestCase, mock, builtins
 
 
 class TestComponent(ComponentTestCase):

--- a/tests/storm/serializers/json_serializer_test.py
+++ b/tests/storm/serializers/json_serializer_test.py
@@ -1,12 +1,10 @@
-import mock
-
 try:
     import simplejson as json
     _ = json # pyflakes
 except ImportError:
     import json
 
-from pyleus.compat import StringIO
+from pyleus.compat import StringIO, mock
 from pyleus.storm.serializers.json_serializer import JSONSerializer
 from testing.serializer import SerializerTestCase
 

--- a/tests/storm/serializers/json_serializer_test.py
+++ b/tests/storm/serializers/json_serializer_test.py
@@ -4,7 +4,8 @@ try:
 except ImportError:
     import json
 
-from pyleus.compat import StringIO, mock
+from pyleus.compat import StringIO
+from pyleus.testing import mock
 from pyleus.storm.serializers.json_serializer import JSONSerializer
 from testing.serializer import SerializerTestCase
 

--- a/tests/storm/serializers/msgpack_serializer_test.py
+++ b/tests/storm/serializers/msgpack_serializer_test.py
@@ -1,9 +1,8 @@
-import mock
 import os
 
 import msgpack
 
-from pyleus.compat import BytesIO
+from pyleus.compat import BytesIO, mock
 from pyleus.storm.serializers.msgpack_serializer import MsgpackSerializer
 from testing.serializer import SerializerTestCase
 

--- a/tests/storm/serializers/msgpack_serializer_test.py
+++ b/tests/storm/serializers/msgpack_serializer_test.py
@@ -2,7 +2,8 @@ import os
 
 import msgpack
 
-from pyleus.compat import BytesIO, mock
+from pyleus.compat import BytesIO
+from pyleus.testing import mock
 from pyleus.storm.serializers.msgpack_serializer import MsgpackSerializer
 from testing.serializer import SerializerTestCase
 

--- a/tests/storm/spout_test.py
+++ b/tests/storm/spout_test.py
@@ -1,9 +1,8 @@
 from collections import namedtuple
 import contextlib
 
-from pyleus.compat import mock
 from pyleus.storm import Spout
-from pyleus.testing import ComponentTestCase
+from pyleus.testing import ComponentTestCase, mock
 
 
 class TestSpout(ComponentTestCase):

--- a/tests/storm/spout_test.py
+++ b/tests/storm/spout_test.py
@@ -1,9 +1,7 @@
 from collections import namedtuple
 import contextlib
 
-import mock
-from mock import sentinel
-
+from pyleus.compat import mock
 from pyleus.storm import Spout
 from pyleus.testing import ComponentTestCase
 
@@ -21,26 +19,18 @@ class TestSpout(ComponentTestCase):
 
     @contextlib.contextmanager
     def _test_emit_helper(self, expected_command_dict):
-        patches = contextlib.nested(
-            mock.patch.object(self.instance, 'read_taskid'),
-            mock.patch.object(self.instance, 'send_command'),
-        )
-
-        with patches as (mock_read_taskid, mock_send_command):
-            yield mock_send_command
+        with mock.patch.object(self.instance, 'read_taskid') as mock_read_taskid:
+            with mock.patch.object(self.instance, 'send_command') as mock_send_command:
+                yield mock_send_command
 
         mock_read_taskid.assert_called_once_with()
         mock_send_command.assert_called_once_with('emit', expected_command_dict)
 
     @contextlib.contextmanager
     def _test_emit_no_taskid_helper(self, expected_command_dict):
-        patches = contextlib.nested(
-            mock.patch.object(self.instance, 'read_taskid'),
-            mock.patch.object(self.instance, 'send_command'),
-        )
-
-        with patches as (mock_read_taskid, mock_send_command):
-            yield mock_send_command
+        with mock.patch.object(self.instance, 'read_taskid') as mock_read_taskid:
+            with mock.patch.object(self.instance, 'send_command') as mock_send_command:
+                yield mock_send_command
 
         assert mock_read_taskid.call_count == 0
         mock_send_command.assert_called_once_with('emit', expected_command_dict)
@@ -92,30 +82,30 @@ class TestSpout(ComponentTestCase):
 
     def test_emit_with_stream(self):
         expected_command_dict = {
-            'stream': sentinel.stream,
+            'stream': mock.sentinel.stream,
             'tuple': (1, 2, 3),
         }
 
         with self._test_emit_helper(expected_command_dict):
-            self.instance.emit((1, 2, 3), stream=sentinel.stream)
+            self.instance.emit((1, 2, 3), stream=mock.sentinel.stream)
 
     def test_emit_with_tup_id(self):
         expected_command_dict = {
-            'id': sentinel.tup_id,
+            'id': mock.sentinel.tup_id,
             'tuple': (1, 2, 3),
         }
 
         with self._test_emit_helper(expected_command_dict):
-            self.instance.emit((1, 2, 3), tup_id=sentinel.tup_id)
+            self.instance.emit((1, 2, 3), tup_id=mock.sentinel.tup_id)
 
     def test_emit_with_direct_task(self):
         expected_command_dict = {
-            'task': sentinel.direct_task,
+            'task': mock.sentinel.direct_task,
             'tuple': (1, 2, 3),
         }
 
         with self._test_emit_helper(expected_command_dict):
-            self.instance.emit((1, 2, 3), direct_task=sentinel.direct_task)
+            self.instance.emit((1, 2, 3), direct_task=mock.sentinel.direct_task)
 
     def test__handle_command_next(self):
         msg = dict(command='next')
@@ -125,15 +115,15 @@ class TestSpout(ComponentTestCase):
         mock_next_tuple.assert_called_once_with()
 
     def test__handle_command_ack(self):
-        msg = dict(command='ack', id=sentinel.tuple_id)
+        msg = dict(command='ack', id=mock.sentinel.tuple_id)
         with mock.patch.object(self.instance, 'ack') as mock_ack:
             self.instance._handle_command(msg)
 
-        mock_ack.assert_called_once_with(sentinel.tuple_id)
+        mock_ack.assert_called_once_with(mock.sentinel.tuple_id)
 
     def test__handle_command_fail(self):
-        msg = dict(command='fail', id=sentinel.tuple_id)
+        msg = dict(command='fail', id=mock.sentinel.tuple_id)
         with mock.patch.object(self.instance, 'fail') as mock_fail:
             self.instance._handle_command(msg)
 
-        mock_fail.assert_called_once_with(sentinel.tuple_id)
+        mock_fail.assert_called_once_with(mock.sentinel.tuple_id)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,6 +1,6 @@
 import os
 
-from pyleus.compat import mock
+from pyleus.testing import mock
 import pyleus.utils as utils
 
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,7 +1,6 @@
 import os
 
-import mock
-
+from pyleus.compat import mock
 import pyleus.utils as utils
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27
+envlist = py26, py27, py31, py32, py33, py34
 # tox has no use_wheel option
 install_cmd = pip install --pre --use-wheel {opts} {packages}
 


### PR DESCRIPTION
- Introduces the six library as a dependency and places the used modules
  into pyleus.compat.
- Some changes to how objects are mocked to keep things compatible with
  Py2 and Py3 versions. Nested context managers had to be changed since 
  2.6 doesn’t support the multiple managers in one with stmt and 3.1+ drops
  support for the contextlib.nested manager.
- Updated tox.ini and all tests are passing for py26, py27, py31, py32, 
  py33, and py34.

The tests are working for me now so as long as the tests cover the code well then everything should work.

Addresses #15 and #37
