### PR TITLE
Fix loss of precision during java serialization 

### DIFF
--- a/topology_builder/src/main/java/com/yelp/pyleus/serializer/MessagePackSerializer.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/serializer/MessagePackSerializer.java
@@ -146,7 +146,7 @@ public class MessagePackSerializer implements ISerializer {
             case INTEGER:
                 return element.asIntegerValue().getLong();
             case FLOAT:
-                return element.asFloatValue().getFloat();
+                return element.asFloatValue().getDouble();
             case BOOLEAN:
                 return element.asBooleanValue().getBoolean();
             case NIL:


### PR DESCRIPTION
Python floating point numbers are always represented by the Java double type. 
This will prevent the loss of precision that occurred with the cast to float.
