### PR TITLE
Added --always-copy to virtualenv call

### DIFF
--- a/pyleus/cli/virtualenv_proxy.py
+++ b/pyleus/cli/virtualenv_proxy.py
@@ -53,7 +53,7 @@ class VirtualenvProxy(object):
 
     def _create_virtualenv(self):
         """Creates the actual virtualenv"""
-        cmd = ["virtualenv", self.path]
+        cmd = ["virtualenv", "--always-copy", self.path]
         if self._system_site_packages:
             cmd.append("--system-site-packages")
 

--- a/tests/cli/virtualenv_proxy_test.py
+++ b/tests/cli/virtualenv_proxy_test.py
@@ -58,7 +58,7 @@ class TestVirtualenvProxyCreation(object):
                                system_site_packages=True,
                                verbose=True)
         mock_cmd.assert_called_once_with(
-            ["virtualenv", VENV_PATH, "--system-site-packages"],
+            ["virtualenv", "--always-copy", VENV_PATH, "--system-site-packages"],
             stdout=venv._out_stream,
             stderr=venv._err_stream,
             err_msg=mock.ANY
@@ -72,7 +72,7 @@ class TestVirtualenvProxyCreation(object):
                                system_site_packages=False,
                                verbose=True)
         mock_cmd.assert_called_once_with(
-            ["virtualenv", VENV_PATH],
+            ["virtualenv", "--always-copy", VENV_PATH],
             stdout=venv._out_stream,
             stderr=venv._err_stream,
             err_msg=mock.ANY


### PR DESCRIPTION
This make it so that the files in the vent are copied from the source 
machine when creating the jar files. If this is not present, recent versions 
of virtualenv will symlink and cause bad links in the jar files. Bad links 
mean that the files will not exist when the jar is actually run. This fix 
ensures that all required files in the venv are copied over so you do not 
actually have to have python installed on your pyleus cluster.

This is the root cause of the `ImportError: No module named 'encodings'` problem in #50
