### PR TITLE
Add comment to cast to tuple

### DIFF
--- a/pyleus/storm/bolt.py
+++ b/pyleus/storm/bolt.py
@@ -119,10 +119,9 @@ class Bolt(Component):
 
         command_dict = {
             'anchors': [anchor.id for anchor in anchors],
-            # Latest versions of simplejson serialize namedtuple as dict,
-            # which is not what storm expects as tuple.
-            # Cast always to tuple in order to have a consistent
-            # behaviour among msgpack, json and simplejson.
+            # Different versions of simplejson serialize namedtuples differently.
+            # Cast to tuple in order to have consistent
+            # behavior between msgpack, json and simplejson.
             'tuple': tuple(values),
         }
 

--- a/pyleus/storm/bolt.py
+++ b/pyleus/storm/bolt.py
@@ -119,6 +119,10 @@ class Bolt(Component):
 
         command_dict = {
             'anchors': [anchor.id for anchor in anchors],
+            # Latest versions of simplejson serialize namedtuple as dict,
+            # which is not what storm expects as tuple.
+            # Cast always to tuple in order to have a consistent
+            # behaviour among msgpack, json and simplejson.
             'tuple': tuple(values),
         }
 

--- a/pyleus/storm/spout.py
+++ b/pyleus/storm/spout.py
@@ -113,6 +113,10 @@ class Spout(Component):
         assert isinstance(values, list) or isinstance(values, tuple)
 
         command_dict = {
+            # Latest versions of simplejson serialize namedtuple as dict,
+            # which is not what storm expects as tuple.
+            # Cast always to tuple in order to have a consistent
+            # behaviour among msgpack, json and simplejson.
             'tuple': tuple(values),
         }
 

--- a/pyleus/storm/spout.py
+++ b/pyleus/storm/spout.py
@@ -113,10 +113,9 @@ class Spout(Component):
         assert isinstance(values, list) or isinstance(values, tuple)
 
         command_dict = {
-            # Latest versions of simplejson serialize namedtuple as dict,
-            # which is not what storm expects as tuple.
-            # Cast always to tuple in order to have a consistent
-            # behaviour among msgpack, json and simplejson.
+            # Different versions of simplejson serialize namedtuples differently.
+            # Cast to tuple in order to have consistent
+            # behavior between msgpack, json and simplejson.
             'tuple': tuple(values),
         }
 


### PR DESCRIPTION
Add a comment to explain why we cast to tuple before serializing the command.
