### PR TITLE
Expose virtualenv --python as yaml option

### DIFF
--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -44,6 +44,10 @@ Topology level options
 
   Path to the file listing topology requirements. Default: ``<yaml_file_dir>/requirements.txt``. Specify ``none`` if a file corresponds to the default path, but you want to ignore it.
 
+* **python_interpreter**\(``str``\)
+
+  The Python interpreter to use to create the topology virtualenv (exposes ``virtualenv`` ``--python`` option). Default: the interpreter that virtualenv was installed with (``/usr/bin/python``).
+
 * **serializer**\(``str``\)
   
   Serializer used by Pyleus for Stom multilang messages. Allowed: ``msgpack``, ``json``. Default: ``msgpack``.

--- a/pyleus/cli/build.py
+++ b/pyleus/cli/build.py
@@ -84,7 +84,7 @@ def _remove_pyleus_base_jar(venv):
 
 def _set_up_virtualenv(venv_name, tmp_dir, req,
                        include_packages, system_site_packages,
-                       pypi_index_url, verbose):
+                       pypi_index_url, python_interpreter, verbose):
     """Create a virtualenv with the specified options and the default packages
     specified in configuration. Then run `pip install -r [requirements file]`.
     """
@@ -92,6 +92,7 @@ def _set_up_virtualenv(venv_name, tmp_dir, req,
         os.path.join(tmp_dir, venv_name),
         system_site_packages=system_site_packages,
         pypi_index_url=pypi_index_url,
+        python_interpreter=python_interpreter,
         verbose=verbose
     )
 
@@ -171,6 +172,8 @@ def _create_pyleus_jar(original_topology_spec, topology_dir, base_jar,
     if not requirements_filename:
         requirements_filename = DEFAULT_REQUIREMENTS_FILENAME
 
+    python_interpreter = original_topology_spec.python_interpreter
+
     venv = os.path.join(topology_dir, VIRTUALENV_NAME)
     req = os.path.join(topology_dir, requirements_filename)
     if not os.path.isfile(req):
@@ -199,6 +202,7 @@ def _create_pyleus_jar(original_topology_spec, topology_dir, base_jar,
         include_packages=include_packages,
         system_site_packages=system_site_packages,
         pypi_index_url=pypi_index_url,
+        python_interpreter=python_interpreter,
         verbose=verbose)
 
     # Assemble the full version of the topolgy yaml file from the user yaml and

--- a/pyleus/cli/topology_spec.py
+++ b/pyleus/cli/topology_spec.py
@@ -54,10 +54,8 @@ class TopologySpec(object):
                     "Unknown serializer. Allowed: {0}. Found: {1}"
                     .format(SERIALIZERS, specs["serializer"]))
 
-        if "requirements_filename" in specs:
-            self.requirements_filename = specs["requirements_filename"]
-        else:
-            self.requirements_filename = None
+        self.requirements_filename = specs.get("requirements_filename")
+        self.python_interpreter = specs.get("python_interpreter")
 
         self.topology = []
         for component in specs["topology"]:

--- a/pyleus/cli/virtualenv_proxy.py
+++ b/pyleus/cli/virtualenv_proxy.py
@@ -36,12 +36,14 @@ class VirtualenvProxy(object):
                  system_site_packages=False,
                  pypi_index_url=None,
                  use_wheel=True,
+                 python_interpreter=None,
                  verbose=False):
         """Creates the virtualenv with the options specified"""
         self.path = path
         self._system_site_packages = system_site_packages
         self._pypi_index_url = pypi_index_url
         self._use_wheel = use_wheel
+        self._python_interpreter = python_interpreter
 
         self._verbose = verbose
         self._out_stream = None
@@ -57,10 +59,13 @@ class VirtualenvProxy(object):
         if self._system_site_packages:
             cmd.append("--system-site-packages")
 
+        if self._python_interpreter:
+            cmd.extend(["--python", self._python_interpreter])
+
         _exec_shell_cmd(cmd,
                         stdout=self._out_stream, stderr=self._err_stream,
                         err_msg="Failed to create virtualenv: {0}".
-                            format(self.path))
+                                format(self.path))
 
     def install_package(self, package):
         """Interface to `pip install SINGLE_PACKAGE`"""

--- a/tests/cli/build_test.py
+++ b/tests/cli/build_test.py
@@ -70,6 +70,7 @@ class TestBuild(object):
             include_packages=["fruit", "ninja==7.7.7"],
             system_site_packages=True,
             pypi_index_url="http://pypi-ninja.ninjacorp.com/simple",
+            python_interpreter="python2.7",
             verbose=False)
         expected_install = [
             mock.call("pyleus=={0}".format(__version__)),
@@ -92,6 +93,7 @@ class TestBuild(object):
             include_packages=["fruit", "ninja==7.7.7"],
             system_site_packages=True,
             pypi_index_url="http://pypi-ninja.ninjacorp.com/simple",
+            python_interpreter="python2.7",
             verbose=False)
         expected_install = [
             mock.call("pyleus=={0}".format(__version__)),

--- a/tests/cli/virtualenv_proxy_test.py
+++ b/tests/cli/virtualenv_proxy_test.py
@@ -52,6 +52,20 @@ class TestVirtualenvProxyCreation(object):
 
     @mock.patch.object(builtins, 'open', autospec=True)
     @mock.patch.object(virtualenv_proxy, '_exec_shell_cmd', autospec=True)
+    def test__create_virtualenv_no_options(
+            self, mock_cmd, mock_open):
+        venv = VirtualenvProxy(VENV_PATH,
+                               system_site_packages=False,
+                               verbose=True)
+        mock_cmd.assert_called_once_with(
+            ["virtualenv", VENV_PATH],
+            stdout=venv._out_stream,
+            stderr=venv._err_stream,
+            err_msg=mock.ANY
+        )
+
+    @mock.patch.object(builtins, 'open', autospec=True)
+    @mock.patch.object(virtualenv_proxy, '_exec_shell_cmd', autospec=True)
     def test__create_virtualenv_system_site_packages(
             self, mock_cmd, mock_open):
         venv = VirtualenvProxy(VENV_PATH,
@@ -66,13 +80,14 @@ class TestVirtualenvProxyCreation(object):
 
     @mock.patch.object(builtins, 'open', autospec=True)
     @mock.patch.object(virtualenv_proxy, '_exec_shell_cmd', autospec=True)
-    def test__create_virtualenv_no_system_site_packages(
+    def test__create_virtualenv_python_interpreter(
             self, mock_cmd, mock_open):
+        path = "python2.7"
         venv = VirtualenvProxy(VENV_PATH,
-                               system_site_packages=False,
+                               python_interpreter=path,
                                verbose=True)
         mock_cmd.assert_called_once_with(
-            ["virtualenv", VENV_PATH],
+            ["virtualenv", VENV_PATH, "--python", path],
             stdout=venv._out_stream,
             stderr=venv._err_stream,
             err_msg=mock.ANY

--- a/topology_builder/src/main/java/com/yelp/pyleus/spec/TopologySpec.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/spec/TopologySpec.java
@@ -31,6 +31,8 @@ public class TopologySpec {
     public String logging_config;
     @SuppressWarnings("unused")
     public String requirements_filename; // Not used in Java.
+    @SuppressWarnings("unused")
+    public String python_interpreter; // Not used in Java.
 
     private static Constructor getConstructor() {
         Constructor constructor = new Constructor(TopologySpec.class);


### PR DESCRIPTION
Issue https://github.com/Yelp/pyleus/issues/54

The `python_interpreter` yaml option makes possible to build and run topologies with a different python interpreter than the default one.

I also substituted the `requirements_filename` if/else None that was above my new code with a get(), since the logic was the same.

Change is backward-compatible.

Tested running locally the `examples/word_count` topology with all python 2.6 and 2.7 combinations (default:2.6, option:2.6; default:2.6, option: 2.7; default:2.7, option: None; etc). 
