### PR TITLE
Fixed logger name for line spout

### DIFF
--- a/examples/logging/logging_example/line_spout.py
+++ b/examples/logging/logging_example/line_spout.py
@@ -3,7 +3,7 @@ import time
 
 from pyleus.storm import Spout
 
-log = logging.getLogger("line_spout")
+log = logging.getLogger("logging_example.line_spout")
 
 
 class LineSpout(Spout):


### PR DESCRIPTION
Existing logging_example only have log_bolt correctly logging to the expected log file. This pull request updates line spout to log to the expected namespace.
