### PR TITLE
More logging in verbose mode

### DIFF
--- a/pyleus/cli/build.py
+++ b/pyleus/cli/build.py
@@ -6,10 +6,11 @@ object. The caller function should handle PyleusError exceptions.
 from __future__ import absolute_import
 
 import glob
-import re
-import tempfile
+import logging
 import os
+import re
 import shutil
+import tempfile
 import yaml
 import zipfile
 
@@ -26,6 +27,8 @@ RESOURCES_PATH = "resources"
 YAML_FILENAME = "pyleus_topology.yaml"
 DEFAULT_REQUIREMENTS_FILENAME = "requirements.txt"
 VIRTUALENV_NAME = "pyleus_venv"
+
+logger = logging.getLogger(__name__)
 
 
 def _open_jar(base_jar):
@@ -117,6 +120,7 @@ def _assemble_full_topology_yaml(spec, venv, resources_dir):
     """
     for component in spec.topology:
         if component.type == "python":
+            logger.debug('Assemble component module: {0}'.format(component.module))
             description = venv.execute_module(module=component.module,
                                               args=[DESCRIBE_OPT],
                                               cwd=resources_dir)

--- a/pyleus/cli/build.py
+++ b/pyleus/cli/build.py
@@ -28,7 +28,7 @@ YAML_FILENAME = "pyleus_topology.yaml"
 DEFAULT_REQUIREMENTS_FILENAME = "requirements.txt"
 VIRTUALENV_NAME = "pyleus_venv"
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def _open_jar(base_jar):
@@ -120,7 +120,7 @@ def _assemble_full_topology_yaml(spec, venv, resources_dir):
     """
     for component in spec.topology:
         if component.type == "python":
-            logger.debug('Assemble component module: {0}'.format(component.module))
+            log.debug('Assemble component module: {0}'.format(component.module))
             description = venv.execute_module(module=component.module,
                                               args=[DESCRIBE_OPT],
                                               cwd=resources_dir)

--- a/pyleus/cli/cli.py
+++ b/pyleus/cli/cli.py
@@ -4,6 +4,7 @@ based on arguments provided.
 from __future__ import absolute_import
 
 import argparse
+import logging
 
 from pyleus import __version__
 from pyleus.cli.commands.build_subcommand import BuildSubCommand
@@ -49,4 +50,5 @@ def main():
         cls().init_subparser(subparsers)
 
     args = parser.parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.DEBUG)
     args.func(args)

--- a/pyleus/cli/cli.py
+++ b/pyleus/cli/cli.py
@@ -50,5 +50,5 @@ def main():
         cls().init_subparser(subparsers)
 
     args = parser.parse_args()
-    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.DEBUG)
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.WARNING)
     args.func(args)


### PR DESCRIPTION
I ran into an obscure stack trace (i.e. Yaml can't use utf-8 to decode some result) when I supplied my topology with a wrong python module. So I have to modify the original pyleus source code to narrow down which entry was giving me trouble. This PR will allow one to turn on verbose option and supply useful debug output.
- Set log level to DEBUG if verbose option is ON
- Sprinkle debug log before executing module for full topology

Example output:

DEBUG:pyleus.cli.build:Assemble component module: access_log_topology.s3_file_spout
DEBUG:pyleus.cli.build:Assemble component module: access_log_topology.access_log_bolt
