### PR TITLE
Don't delete system-installed base jar on build

### DIFF
--- a/pyleus/cli/build.py
+++ b/pyleus/cli/build.py
@@ -73,13 +73,29 @@ def _validate_venv(topology_dir, venv):
                                    "file named {0}".format(venv))
 
 
+def _path_contained_by(containing_path, path):
+    """Return whether path is a subpath of containing_path"""
+    # Call to os.path.join adds a trailing separator to real_containing_path
+    # without which os.path.commonprefix can be unreliable.
+    real_containing_path = os.path.join(os.path.realpath(containing_path), '')
+    real_path = os.path.realpath(path)
+    common_prefix = os.path.commonprefix([real_containing_path, real_path])
+    return common_prefix == real_containing_path
+
+
 def _remove_pyleus_base_jar(venv):
     """Remove the Pyleus base jar from the virtualenv since it's redundant and
     takes up space. See PYLEUS-74.
+
+    This function verifies that base_jar_path is actually inside the virtualenv
+    before removing it. If the user is using --system-site-packages and has
+    pyleus installed on their system, base_jar_path is actually outside the
+    virtualenv, and we don't want to attempt its removal in that case.
     """
     base_jar_path = venv.execute_module("pyleus._base_jar",
                                         cwd=venv.path).strip()
-    os.remove(base_jar_path)
+    if _path_contained_by(venv.path, base_jar_path):
+        os.remove(base_jar_path)
 
 
 def _set_up_virtualenv(venv_name, tmp_dir, req,


### PR DESCRIPTION
To save space in toplogy jars, the CLI deletes the unnecessary base jar
from the virtualenv before packing it into the topology jar.

This didn't account for users using --system-site-packages, however, and
it would still attempt to delete the base jar from its system-installed
location.

Closes #74 
