### PR TITLE
add autospec to mock.patch.object calls

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -134,7 +134,7 @@ Run your topology on your local machine for debugging:
 .. code-block:: none
 
    pyleus build my_first_topology/pyleus_topology.yaml
-   pyleus local my_first_topology.yaml -d
+   pyleus local my_first_topology.jar -d
 
 The ``-debug`` option will print all tuples flowing through the topology.
 

--- a/tests/cli/storm_cluster_test.py
+++ b/tests/cli/storm_cluster_test.py
@@ -52,7 +52,7 @@ class TestStormCluster(object):
                              "nimbus.thrift.port=4321"]
 
     def test_submit(self, cluster):
-        with mock.patch.object(cluster, '_exec_storm_cmd') as mock_exec:
+        with mock.patch.object(cluster, '_exec_storm_cmd', autospec=True) as mock_exec:
             cluster.submit(mock.sentinel.jar_path)
 
         mock_exec.assert_called_once_with(["jar", mock.sentinel.jar_path, TOPOLOGY_BUILDER_CLASS])

--- a/tests/cli/topologies_test.py
+++ b/tests/cli/topologies_test.py
@@ -30,7 +30,7 @@ def test_submit_topology(configs):
     mock_storm_cluster = mock.Mock()
 
     with mock.patch.object(pyleus.cli.topologies, 'StormCluster',
-            return_value=mock_storm_cluster) as mock_ctr:
+            return_value=mock_storm_cluster, autospec=True) as mock_ctr:
         submit_topology(mock.sentinel.jar_path, configs)
 
     mock_ctr.assert_called_once_with(
@@ -48,7 +48,7 @@ def test_kill_topology(configs):
     mock_storm_cluster = mock.Mock()
 
     with mock.patch.object(pyleus.cli.topologies, 'StormCluster',
-            return_value=mock_storm_cluster) as mock_ctr:
+            return_value=mock_storm_cluster, autospec=True) as mock_ctr:
         kill_topology(configs)
 
     mock_ctr.assert_called_once_with(
@@ -66,7 +66,7 @@ def test_list_topologies(configs):
     mock_storm_cluster = mock.Mock()
 
     with mock.patch.object(pyleus.cli.topologies, 'StormCluster',
-            return_value=mock_storm_cluster) as mock_ctr:
+            return_value=mock_storm_cluster, autospec=True) as mock_ctr:
         list_topologies(configs)
 
     mock_ctr.assert_called_once_with(

--- a/tests/storm/bolt_test.py
+++ b/tests/storm/bolt_test.py
@@ -14,7 +14,7 @@ class TestBolt(ComponentTestCase):
     def test_ack(self):
         tup = mock.Mock(id=1234)
 
-        with mock.patch.object(self.instance, 'send_command') as \
+        with mock.patch.object(self.instance, 'send_command', autospec=True) as \
                 mock_send_command:
             self.instance.ack(tup)
 
@@ -23,7 +23,7 @@ class TestBolt(ComponentTestCase):
     def test_fail(self):
         tup = mock.Mock(id=1234)
 
-        with mock.patch.object(self.instance, 'send_command') as \
+        with mock.patch.object(self.instance, 'send_command', autospec=True) as \
                 mock_send_command:
             self.instance.fail(tup)
 
@@ -31,8 +31,8 @@ class TestBolt(ComponentTestCase):
 
     @contextlib.contextmanager
     def _test_emit_helper(self, expected_command_dict):
-        with mock.patch.object(self.instance, 'read_taskid') as mock_read_taskid:
-            with mock.patch.object(self.instance, 'send_command') as mock_send_command:
+        with mock.patch.object(self.instance, 'read_taskid', autospec=True) as mock_read_taskid:
+            with mock.patch.object(self.instance, 'send_command', autospec=True) as mock_send_command:
                 yield mock_send_command
 
         mock_read_taskid.assert_called_once_with()
@@ -40,8 +40,8 @@ class TestBolt(ComponentTestCase):
 
     @contextlib.contextmanager
     def _test_emit_helper_no_taskid(self, expected_command_dict):
-        with mock.patch.object(self.instance, 'read_taskid') as mock_read_taskid:
-            with mock.patch.object(self.instance, 'send_command') as mock_send_command:
+        with mock.patch.object(self.instance, 'read_taskid', autospec=True) as mock_read_taskid:
+            with mock.patch.object(self.instance, 'send_command', autospec=True) as mock_send_command:
                 yield mock_send_command
 
         assert mock_read_taskid.call_count == 0

--- a/tests/storm/serializers/msgpack_serializer_test.py
+++ b/tests/storm/serializers/msgpack_serializer_test.py
@@ -20,7 +20,7 @@ class TestMsgpackSerializer(SerializerTestCase):
         encoded_msg = msgpack.packb(msg_dict)
 
         with mock.patch.object(
-                os, 'read', return_value=encoded_msg):
+                os, 'read', return_value=encoded_msg, autospec=True):
 
             assert self.instance.read_msg() == msg_dict
 
@@ -30,7 +30,7 @@ class TestMsgpackSerializer(SerializerTestCase):
         encoded_msg = msgpack.packb(msg_list)
 
         with mock.patch.object(
-                os, 'read', return_value=encoded_msg):
+                os, 'read', return_value=encoded_msg, autospec=True):
 
             assert self.instance.read_msg() == msg_list
 

--- a/tests/storm/spout_test.py
+++ b/tests/storm/spout_test.py
@@ -10,7 +10,7 @@ class TestSpout(ComponentTestCase):
     INSTANCE_CLS = Spout
 
     def test__sync(self):
-        with mock.patch.object(self.instance, 'send_command') \
+        with mock.patch.object(self.instance, 'send_command', autospec=True) \
                as mock_send_command:
             self.instance._sync()
 
@@ -18,8 +18,8 @@ class TestSpout(ComponentTestCase):
 
     @contextlib.contextmanager
     def _test_emit_helper(self, expected_command_dict):
-        with mock.patch.object(self.instance, 'read_taskid') as mock_read_taskid:
-            with mock.patch.object(self.instance, 'send_command') as mock_send_command:
+        with mock.patch.object(self.instance, 'read_taskid', autospec=True) as mock_read_taskid:
+            with mock.patch.object(self.instance, 'send_command', autospec=True) as mock_send_command:
                 yield mock_send_command
 
         mock_read_taskid.assert_called_once_with()
@@ -27,8 +27,8 @@ class TestSpout(ComponentTestCase):
 
     @contextlib.contextmanager
     def _test_emit_no_taskid_helper(self, expected_command_dict):
-        with mock.patch.object(self.instance, 'read_taskid') as mock_read_taskid:
-            with mock.patch.object(self.instance, 'send_command') as mock_send_command:
+        with mock.patch.object(self.instance, 'read_taskid', autospec=True) as mock_read_taskid:
+            with mock.patch.object(self.instance, 'send_command', autospec=True) as mock_send_command:
                 yield mock_send_command
 
         assert mock_read_taskid.call_count == 0
@@ -108,21 +108,21 @@ class TestSpout(ComponentTestCase):
 
     def test__handle_command_next(self):
         msg = dict(command='next')
-        with mock.patch.object(self.instance, 'next_tuple') as mock_next_tuple:
+        with mock.patch.object(self.instance, 'next_tuple', autospec=True) as mock_next_tuple:
             self.instance._handle_command(msg)
 
         mock_next_tuple.assert_called_once_with()
 
     def test__handle_command_ack(self):
         msg = dict(command='ack', id=mock.sentinel.tuple_id)
-        with mock.patch.object(self.instance, 'ack') as mock_ack:
+        with mock.patch.object(self.instance, 'ack', autospec=True) as mock_ack:
             self.instance._handle_command(msg)
 
         mock_ack.assert_called_once_with(mock.sentinel.tuple_id)
 
     def test__handle_command_fail(self):
         msg = dict(command='fail', id=mock.sentinel.tuple_id)
-        with mock.patch.object(self.instance, 'fail') as mock_fail:
+        with mock.patch.object(self.instance, 'fail', autospec=True) as mock_fail:
             self.instance._handle_command(msg)
 
         mock_fail.assert_called_once_with(mock.sentinel.tuple_id)


### PR DESCRIPTION
I think we do want autospec=True on most of the mock.patch.object calls since default is False.
