### PR TITLE
Fix ClassCastException in PyleusTopologyBuilder.handleKafkaSpout()

### DIFF
--- a/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
@@ -152,9 +152,9 @@ public class PyleusTopologyBuilder {
             config.forceFromStart = forceFromStart;
         }
 
-        Long startOffsetTime = (Long) spec.options.get("start_offset_time");
+        Object startOffsetTime = spec.options.get("start_offset_time");
         if (startOffsetTime != null) {
-            config.startOffsetTime = startOffsetTime;
+            config.startOffsetTime = Long.valueOf(startOffsetTime.toString());
         }
 
         // TODO: this mandates that messages are UTF-8. We should allow for binary data


### PR DESCRIPTION
Fixes ClassCastException when the yaml parser identifies the start_offset_time setting for a KafkaSpout as an Integer instead of a Long. Also fixes a NullPointerException when start_offset_time is not defined in the topology yaml for a KafkaSpout (since you can't cast a `null` to a `Long`).

Closes #93 
