### PR TITLE
API for adding java-based spouts to Pyleus topologies

### DIFF
--- a/docs/source/external.rst
+++ b/docs/source/external.rst
@@ -1,0 +1,137 @@
+.. _external:
+
+Integrating with java-based spouts
+==================================
+
+Pyleus topologies can include externally defined spouts, in order to enable integration with `existing Storm spout libraries`_ or other custom data sources. Pyleus ships with a ``kafka`` spout provider but you implement your own
+providers to expose include other java-based spouts in your pyleus topologies as well.
+
+Implementing a spout provider
+-----------------------------
+
+In order to give Pyleus topologies access to a java-based spout, you need to implement a ``java`` class class that can 
+extract any relevant configuration information provided in your topology yaml file and use it to create an instance of the spout in question. 
+
+Your java class must implement the ``com.yelp.pyleus.SpoutProvider`` interface. This interface requires you to implement the following method: 
+
+.. code-block:: java
+
+   public IRichSpout provide(final TopologyBuilder builder, final SpoutSpec spec) { }
+
+If you use ``maven`` you can add the ``pyleus-base`` project and ``storm-core`` as dependencies in order to include the above interface and its related classes: 
+
+.. code-block:: xml
+
+   <dependencies>
+      <dependency>
+         <groupId>com.yelp.pyleus</groupId>
+         <artifactId>pyleus-base</artifactId>
+         <version>0.2.4</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.storm</groupId>
+         <artifactId>storm-core</artifactId>
+         <version>0.9.2-incubating</version>
+         <scope>provided</scope>
+      </dependency>
+   </dependencies>
+
+.. note::
+
+  Because the ``pyleus-base`` is not currently available in Maven Central, you will need to build it from source and install it in your local environment, nexus server or manually add it to your classpath if you are not using ``maven``:
+
+    #. Checkout the Pyleus project using git: ``git clone https://github.com/Yelp/pyleus.git``
+    #. Run the ``mvn install`` command from the ``pyleus/topology_builder/`` directory. The ``pyleus-base-0.2.4.jar`` should now be available in the ``pyleus/topology_builder/target/`` directory and in your local maven repository cache.
+
+You can extract any spout configuration parameters provided in the ``options`` section of your topology yaml file via the ``SpoutSpec`` object that is passed into the ``provide()`` method. ``Spoutspec.options`` is a map of ``String`` parameter names to their ``Object`` values. 
+
+For example, given this external spout declaration in a pyleus topology yaml:
+
+.. code-block:: yaml
+
+   - spout:
+        name: sentence-spout
+        type: sentence
+        output_fields: 
+          - sentence
+        options:
+          sentence: This is a sentence that will be emitted twice a second.
+          sentencesPerMin: 120
+
+The specified options can be extracted from ``SpoutSpec`` in your ``SpoutProvider`` implementation as follows:
+
+.. code-block:: java
+
+  // extracting Strings:
+  String sentence = "No Sentence Specified";
+  Object o = spec.options.get("sentence");
+  if (o != null && o instanceof String)
+     sentence = (String) o;
+
+  // extracting numeric types:
+  Integer sentencesPerMin = null;
+  o = spec.options.get("sentencesPerMin");
+  if (o != null)
+    // this will fail fast in case of non-null, invalid numeric value.
+    sentencesPerMin = Integer.valueOf(o.toString());
+
+.. seealso::
+
+   You can find a functional example of a java spout provider in the ``java_spout_provider`` example in the `GitHub repo`_, in the ``java_spout_src`` directory.
+
+Adding spout providers to pyleus.conf
+-------------------------------------
+
+Once you have implemented a ``SpoutProvider`` and compiled it into a ``.jar``, you make it available to your pyleus projects by adding it to the ``pyleus.conf`` you use to build your topologies. Each spout provider should have an alias in the ``plugins`` section of that file as follows:
+
+.. code-block:: ini
+
+  [plugins]
+  alias: full.class.name.of.SpoutProviderImpl
+  example_sp: com.example.ExampleSpoutProvider
+
+The alias(es) defined in the plugin section can be refereces as spout ``types`` in your topology file. Any options defined in your topology yaml will be passed to an instance of the the spout provider java class associated with that alias.
+
+In addition to adding the spout provider class, you aslo need to add your spout provider jar, along with any other required java dependencies by defining the ``include_java_jars`` property in the ``build`` section of your ``pyleus.conf``. You can specify multiple jar files seperated by spaces and/or directories containing jar files. For example:
+
+.. code-block:: ini
+  
+  [build]
+  include_java_jars: /path/to/my/spout_provider.jar ~/another.jar /some/directory/full/of/jars
+
+.. danger:: 
+
+  Do not include any dependencies that are already part of the Storm distribution or already included with Pyleus. Any classes including by pyleus during the build process will replace identically named classes in the java jars you include, so referencing a different version of a jar included with Pyleus can also cause errors.
+
+.. seealso::
+
+  See :ref:`configuration` for a list of all the settings supported in the Pyleus configuration file.
+
+Adding external spouts to your topology
+---------------------------------------
+
+Once your spout providers have been added to your ``pyleus.conf`` you can add them as spouts in your topology yaml.
+
+.. code-block:: yaml
+
+  - spout:
+    name: sentence-spout
+    type: sentence
+    output_fields: 
+      - sentence
+    options:
+      sentence: This is a sentence that will be emitted twice a second.
+      sentencesPerMin: 120
+
+The ``type`` should match one of the alias values defined in the ``plugins`` section of your ``pyleus.conf`` file.
+
+The ``output_fields`` is a list of the output values emitted by the spout.
+
+Any additional properties specified under ``options`` will also be passed to the spout provider.
+
+Once the spout is defined in your topology you can reference it by name in your bolt definitions the same way that you would with normal Pyleus bolt.
+
+
+.. _existing Storm spout libraries: https://storm.apache.org/about/integrates.html
+.. _GitHub repo: https://github.com/Yelp/pyleus/tree/develop/examples

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,6 +70,7 @@ Documentation
    options
    parallelism
    tick
+   external
    logging
    yaml
    install

--- a/examples/java_spout_provider/java_spout_src/pom.xml
+++ b/examples/java_spout_provider/java_spout_src/pom.xml
@@ -18,4 +18,19 @@
          <scope>provided</scope>
       </dependency>
    </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>2.3.1</version>
+            <configuration>
+               <source>1.7</source>
+               <target>1.7</target>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+
 </project>

--- a/examples/java_spout_provider/java_spout_src/pom.xml
+++ b/examples/java_spout_provider/java_spout_src/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>com.yelp.pyleus</groupId>
+   <artifactId>example-spout-provider</artifactId>
+   <version>0.0.1-SNAPSHOT</version>
+
+   <dependencies>
+      <dependency>
+         <groupId>com.yelp.pyleus</groupId>
+         <artifactId>pyleus-base</artifactId>
+         <version>0.2.4</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.storm</groupId>
+         <artifactId>storm-core</artifactId>
+         <version>0.9.2-incubating</version>
+         <scope>provided</scope>
+      </dependency>
+   </dependencies>
+</project>

--- a/examples/java_spout_provider/java_spout_src/src/main/java/com/yelp/pyleus/example/ExampleSpout.java
+++ b/examples/java_spout_provider/java_spout_src/src/main/java/com/yelp/pyleus/example/ExampleSpout.java
@@ -1,0 +1,46 @@
+package com.yelp.pyleus.example;
+
+import java.util.Map;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.base.BaseRichSpout;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Values;
+import backtype.storm.utils.Utils;
+
+public class ExampleSpout extends BaseRichSpout {
+
+   private static final long serialVersionUID = 1L;
+
+   private SpoutOutputCollector collector;
+   private final String sentence;
+   private int sentencesPerMin = 30;
+
+   public ExampleSpout(String sentence) {
+      this.sentence = sentence;
+   }
+
+   public void nextTuple() {
+      Utils.sleep(1000 * 60 / sentencesPerMin);
+      collector.emit(new Values(sentence));
+   }
+
+   public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
+      this.collector = collector;
+   }
+
+   public void declareOutputFields(OutputFieldsDeclarer declarer) {
+      declarer.declare(new Fields("sentence"));
+   }
+
+   public int getSentencesPerMin() {
+      return sentencesPerMin;
+   }
+
+   public void setSentencesPerMin(int sentencesPerMin) {
+      this.sentencesPerMin = sentencesPerMin;
+   }
+
+}

--- a/examples/java_spout_provider/java_spout_src/src/main/java/com/yelp/pyleus/example/ExampleSpoutProvider.java
+++ b/examples/java_spout_provider/java_spout_src/src/main/java/com/yelp/pyleus/example/ExampleSpoutProvider.java
@@ -1,0 +1,29 @@
+package com.yelp.pyleus.example;
+
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.TopologyBuilder;
+
+import com.yelp.pyleus.SpoutProvider;
+import com.yelp.pyleus.spec.SpoutSpec;
+
+public class ExampleSpoutProvider implements SpoutProvider {
+
+   public IRichSpout provide(TopologyBuilder builder, SpoutSpec spec) {
+      String sentence = "No Sentence Specified";
+      Object o = spec.options.get("sentence");
+      if (o != null && o instanceof String)
+         sentence = (String) o;
+
+      Integer sentencesPerMin = null;
+      o = spec.options.get("sentencesPerMin");
+      if (o != null)
+         // this will fail fast in case of non-null, invalid numeric value.
+         sentencesPerMin = Integer.valueOf(o.toString());
+
+      ExampleSpout out = new ExampleSpout(sentence);
+      if (sentencesPerMin != null && sentencesPerMin.intValue() > 0)
+         out.setSentencesPerMin(sentencesPerMin);
+      return out;
+   }
+
+}

--- a/examples/java_spout_provider/pyleus.conf
+++ b/examples/java_spout_provider/pyleus.conf
@@ -1,0 +1,7 @@
+[build]
+pypi_index_url: http://0.0.0.0:7778/simple/
+
+include_java_jars: /home/mzbyszynski/projects/pyleus/examples/java_spout_provider/java_spout_src/target/example-spout-provider-0.0.1-SNAPSHOT.jar
+
+[plugins]
+sentence: com.yelp.pyleus.example.ExampleSpoutProvider

--- a/examples/java_spout_provider/pyleus.conf
+++ b/examples/java_spout_provider/pyleus.conf
@@ -1,7 +1,7 @@
 [build]
 pypi_index_url: http://0.0.0.0:7778/simple/
 
-include_java_jars: /home/mzbyszynski/projects/pyleus/examples/java_spout_provider/java_spout_src/target/example-spout-provider-0.0.1-SNAPSHOT.jar
+include_java_jars: java_spout_src/target/example-spout-provider-0.0.1-SNAPSHOT.jar
 
 [plugins]
 sentence: com.yelp.pyleus.example.ExampleSpoutProvider

--- a/examples/java_spout_provider/pyleus_topology.yaml
+++ b/examples/java_spout_provider/pyleus_topology.yaml
@@ -1,0 +1,20 @@
+# Very simple example of a topology with an external (java-based) spout.
+
+name: java_spout_provider
+
+topology:
+
+    - spout:
+        name: sentence-spout
+        type: sentence
+        output_fields: 
+          - sentence
+        options:
+          sentence: This is a sentence that will be emitted twice a second.
+          sentencesPerMin: 120
+
+    - bolt:
+        name: sentence-consumer-bolt
+        module: sentence_consumer.word_counting_bolt
+        groupings:
+          - shuffle_grouping: sentence-spout

--- a/examples/java_spout_provider/sentence_consumer/word_counting_bolt.py
+++ b/examples/java_spout_provider/sentence_consumer/word_counting_bolt.py
@@ -1,0 +1,13 @@
+from pyleus.storm import SimpleBolt
+
+class WordCountingBolt(SimpleBolt):
+
+  OUTPUT_FIELDS = ["wc"]
+
+  def process_tuple(self, tup):
+    sentence = tup.values[0]
+    cnt = len(sentence.split())
+    self.emit((cnt,), anchors=[tup])
+
+if __name__ == '__main__':
+  WordCountingBolt().run()

--- a/pyleus/cli/topologies.py
+++ b/pyleus/cli/topologies.py
@@ -24,7 +24,8 @@ def run_topology_locally(jar_path, configs):
         configs.storm_cmd_path,
         jar_path,
         configs.debug,
-        configs.jvm_opts)
+        configs.jvm_opts,
+        configs.plugins)
 
 
 def submit_topology(jar_path, configs):
@@ -34,7 +35,8 @@ def submit_topology(jar_path, configs):
         configs.nimbus_host,
         configs.nimbus_port,
         configs.verbose,
-        configs.jvm_opts).submit(jar_path)
+        configs.jvm_opts,
+        configs.plugins).submit(jar_path)
 
 
 def list_topologies(configs):
@@ -44,7 +46,8 @@ def list_topologies(configs):
         configs.nimbus_host,
         configs.nimbus_port,
         configs.verbose,
-        configs.jvm_opts).list()
+        configs.jvm_opts,
+        configs.plugins).list()
 
 
 def kill_topology(configs):
@@ -54,7 +57,8 @@ def kill_topology(configs):
         configs.nimbus_host,
         configs.nimbus_port,
         configs.verbose,
-        configs.jvm_opts).kill(configs.topology_name, configs.wait_time)
+        configs.jvm_opts,
+        configs.plugins).kill(configs.topology_name, configs.wait_time)
 
 
 def is_jar(jar_path):

--- a/pyleus/cli/topology_spec.py
+++ b/pyleus/cli/topology_spec.py
@@ -307,8 +307,11 @@ class SpoutSpec(ComponentSpec):
                     .format(self.name, "module"))
             self.module = specs["module"]
 
-        if self.type == "kafka":
+        elif self.type == "kafka":
             self.output_fields = {DEFAULT_STREAM: ["message"]}
+
+        else:
+            self.output_fields = {DEFAULT_STREAM: specs['output_fields']}
 
     def update_from_module(self, specs):
         """Specific spout validation. Spouts must have output fields."""

--- a/pyleus/configuration.py
+++ b/pyleus/configuration.py
@@ -44,6 +44,10 @@ invocations.
    # list of packages to always include in your topologies
    include_packages: foo bar<4.0 baz==0.1
 
+   # list of .jar files or directories of .jar files that will be 
+   # added to the classpath of your topology separated by spaces.
+   include_java_jars: /home/my/plugin/some.jar /home/also/works/for/directories
+
    [plugins]
    # list any external spout providers referenced in your yaml and the
    # java classes they correspond to.
@@ -72,8 +76,8 @@ CONFIG_FILES_PATH = [
 
 Configuration = collections.namedtuple(
     "Configuration",
-    "base_jar config_file debug func include_packages output_jar \
-     pypi_index_url nimbus_host nimbus_port storm_cmd_path \
+    "base_jar config_file debug func include_packages include_java_jars \
+     output_jar pypi_index_url nimbus_host nimbus_port storm_cmd_path \
      system_site_packages topology_path topology_jar topology_name verbose \
      wait_time jvm_opts plugins"
 )
@@ -86,6 +90,7 @@ DEFAULTS = Configuration(
     debug=False,
     func=None,
     include_packages=None,
+    include_java_jars=None,
     output_jar=None,
     pypi_index_url=None,
     nimbus_host=None,

--- a/tests/cli/topologies_test.py
+++ b/tests/cli/topologies_test.py
@@ -39,6 +39,7 @@ def test_submit_topology(configs):
         configs.nimbus_port,
         configs.verbose,
         configs.jvm_opts,
+        configs.plugins,
     )
 
     mock_storm_cluster.submit.assert_called_once_with(mock.sentinel.jar_path)
@@ -57,6 +58,7 @@ def test_kill_topology(configs):
         configs.nimbus_port,
         configs.verbose,
         configs.jvm_opts,
+        configs.plugins,
     )
 
     mock_storm_cluster.kill.assert_called_once_with(configs.topology_name, configs.wait_time)
@@ -75,6 +77,7 @@ def test_list_topologies(configs):
         configs.nimbus_port,
         configs.verbose,
         configs.jvm_opts,
+        configs.plugins,
     )
 
     mock_storm_cluster.list.assert_called_once_with()

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -37,3 +37,39 @@ class TestConfiguration(object):
         assert default_config.pypi_index_url == None
         assert updated_config.pypi_index_url == \
                        "http://pypi-ninja.ninjacorp.com/simple"
+
+    def test_update_configuration_with_plugins(self):
+        default_config = configuration.DEFAULTS
+        update_dict = {
+            "plugins": [("a","some.Class"), ("b","some.other.Class")]
+        }
+        updated_config = configuration.update_configuration(
+            default_config, update_dict)
+        assert default_config.plugins == []
+        assert updated_config.plugins == [
+            ("a","some.Class"), 
+            ("b","some.other.Class")
+        ]
+
+    @mock.patch.object(os.path, "exists", autospec=True)
+    @mock.patch.object(os.path, "isfile", autospec=True)
+    @mock.patch("pyleus.configuration.configparser.SafeConfigParser")
+    def test_load_configuration_with_plugins(
+            self, mock_isfile, mock_exists, MockSafeConfigParser):
+
+        expected_plugins = [
+            ("alias1", "java.class.named.Alias1"),
+            ("alias2", "java.class.named.Alias2")
+        ]
+
+        def get_plugins(arg=None): 
+            if arg == "plugins":
+                return expected_plugins
+            else:
+                return []
+
+        cfp = configuration.configparser.SafeConfigParser()
+        cfp.items.side_effect = get_plugins
+        config = configuration.load_configuration("")
+        cfp.items.assert_called_with("plugins")
+        assert config.plugins == expected_plugins

--- a/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
@@ -20,6 +20,7 @@ import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.tuple.Fields;
 
 import com.yelp.pyleus.bolt.PythonBolt;
+import com.yelp.pyleus.kafka.KafkaSpoutProvider;
 import com.yelp.pyleus.spec.BoltSpec;
 import com.yelp.pyleus.spec.ComponentSpec;
 import com.yelp.pyleus.spec.SpoutSpec;
@@ -39,6 +40,10 @@ public class PyleusTopologyBuilder {
     private static final String PROVIDER_ARG_PFIX = "--provider.";
 
     private static final Map<String, String> providers = new HashMap<String, String>();
+
+    static {
+        providers.put("kafka", KafkaSpoutProvider.class.getCanonicalName());
+    }
 
     public static void handleBolt(final TopologyBuilder builder, final BoltSpec spec,
             final TopologySpec topologySpec) {

--- a/topology_builder/src/main/java/com/yelp/pyleus/SpoutProvider.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/SpoutProvider.java
@@ -7,6 +7,6 @@ import com.yelp.pyleus.spec.SpoutSpec;
 
 public interface SpoutProvider {
 
-   IRichSpout handleKafkaSpout(final TopologyBuilder builder,
+   IRichSpout provide(final TopologyBuilder builder,
             final SpoutSpec spec);
 }

--- a/topology_builder/src/main/java/com/yelp/pyleus/SpoutProvider.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/SpoutProvider.java
@@ -1,0 +1,12 @@
+package com.yelp.pyleus;
+
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.TopologyBuilder;
+
+import com.yelp.pyleus.spec.SpoutSpec;
+
+public interface SpoutProvider {
+
+   IRichSpout handleKafkaSpout(final TopologyBuilder builder,
+            final SpoutSpec spec);
+}

--- a/topology_builder/src/main/java/com/yelp/pyleus/kafka/KafkaSpoutProvider.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/kafka/KafkaSpoutProvider.java
@@ -1,0 +1,62 @@
+package com.yelp.pyleus.kafka;
+
+import storm.kafka.KafkaSpout;
+import storm.kafka.KeyValueSchemeAsMultiScheme;
+import storm.kafka.SpoutConfig;
+import storm.kafka.StringKeyValueScheme;
+import storm.kafka.ZkHosts;
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.TopologyBuilder;
+
+import com.yelp.pyleus.SpoutProvider;
+import com.yelp.pyleus.spec.SpoutSpec;
+
+public class KafkaSpoutProvider implements SpoutProvider {
+
+   public static final String KAFKA_ZK_ROOT_FMT = "/pyleus-kafka-offsets/%s";
+   public static final String KAFKA_CONSUMER_ID_FMT = "pyleus-%s";
+
+   @Override
+   public IRichSpout handleKafkaSpout(TopologyBuilder builder, SpoutSpec spec) {
+      String topic = (String) spec.options.get("topic");
+      if (topic == null) { throw new RuntimeException("Kafka spout must have topic"); }
+
+      String zkHosts = (String) spec.options.get("zk_hosts");
+      if (zkHosts == null) { throw new RuntimeException("Kafka spout must have zk_hosts"); }
+
+      String zkRoot = (String) spec.options.get("zk_root");
+      if (zkRoot == null) {
+         zkRoot = String.format(KAFKA_ZK_ROOT_FMT, spec.name);
+      }
+
+      String consumerId = (String) spec.options.get("consumer_id");
+      if (consumerId == null) {
+         consumerId = String.format(KAFKA_CONSUMER_ID_FMT, spec.name);
+      }
+
+      SpoutConfig config = new SpoutConfig(
+               new ZkHosts(zkHosts),
+               topic,
+               zkRoot,
+               consumerId
+               );
+
+      Boolean forceFromStart = (Boolean) spec.options.get("from_start");
+      if (forceFromStart != null) {
+         config.forceFromStart = forceFromStart;
+      }
+
+      Long startOffsetTime = (Long) spec.options.get("start_offset_time");
+      if (startOffsetTime != null) {
+         config.startOffsetTime = startOffsetTime;
+      }
+
+      // TODO: this mandates that messages are UTF-8. We should allow for binary data
+      // in the future, or once users can have Java components, let them provide their
+      // own JSON serialization method. Or wait on STORM-138.
+      config.scheme = new KeyValueSchemeAsMultiScheme(new StringKeyValueScheme());
+
+      return new KafkaSpout(config);
+   }
+
+}

--- a/topology_builder/src/main/java/com/yelp/pyleus/kafka/KafkaSpoutProvider.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/kafka/KafkaSpoutProvider.java
@@ -17,7 +17,7 @@ public class KafkaSpoutProvider implements SpoutProvider {
    public static final String KAFKA_CONSUMER_ID_FMT = "pyleus-%s";
 
    @Override
-   public IRichSpout handleKafkaSpout(TopologyBuilder builder, SpoutSpec spec) {
+   public IRichSpout provide(TopologyBuilder builder, SpoutSpec spec) {
       String topic = (String) spec.options.get("topic");
       if (topic == null) { throw new RuntimeException("Kafka spout must have topic"); }
 

--- a/topology_builder/src/main/java/com/yelp/pyleus/kafka/KafkaSpoutProvider.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/kafka/KafkaSpoutProvider.java
@@ -46,9 +46,9 @@ public class KafkaSpoutProvider implements SpoutProvider {
          config.forceFromStart = forceFromStart;
       }
 
-      Long startOffsetTime = (Long) spec.options.get("start_offset_time");
+      Object startOffsetTime = spec.options.get("start_offset_time");
       if (startOffsetTime != null) {
-         config.startOffsetTime = startOffsetTime;
+         config.startOffsetTime = Long.valueOf(startOffsetTime.toString());
       }
 
       // TODO: this mandates that messages are UTF-8. We should allow for binary data


### PR DESCRIPTION
Adds the ability to integrate java-based spouts with Pyleus topologies, based on the way that the kafka spout was previously integrated into Pyleus.

In a nutshell, to add a java spout to your topology you need to:
1. Write a java class that implements the new `SpoutProvider` interface and package it in a jar.
2. Add the jars you need and the spout type-to-java `SpoutProvider` class mapping to your `pyleus.conf`
3. Add the spout to your topology yaml and define the `type`, `output_fields` and `options`.

**Documentation**
- I added _external.rst_ to the docs, which describes the above steps in greater detail.
- I added a new example project called _java_spout_provider_ that includes the java + python source for creating one of these things.
- Updated the yaml documentation to include the new options.

**Testing:**
- I think I added unit tests to cover all the python changes I made.
- I also manually tested these cases (and verified they were working):
  - java_spout_provider example locally using `pyleus local` with Storm 0.9.3.
  - java_spout_provider on storm cluster using `pyleus submit` with Storm 0.9.3.
  - kafka spout with simple bolt that logs the messages on kafka/storm cluster using `pyleus submit` with Storm 0.9.3 and Kafka 0.8.2.

All questions, feedback and code review comments welcome! I was thinking about adding a readme.md file to the _java_spout_provider_ example, since there are a bunch of steps to build it, but I didn't see anything similar in the other examples so I didn't want to violate any project conventions. Some guidance on that would be great as well.

Thanks!

Closes #93
Closes #91
