### PR TITLE
Support logging levels and upgrade to Storm 0.9.3 (#10)

### DIFF
--- a/docs/source/storm/component.rst
+++ b/docs/source/storm/component.rst
@@ -6,7 +6,7 @@ pyleus.storm.component
 .. automodule:: pyleus.storm.component
 
     .. autoclass:: Component
-        :members: initialize, OUTPUT_FIELDS, OPTIONS, options, conf, context, run
+        :members: initialize, OUTPUT_FIELDS, OPTIONS, options, conf, context, run, log, log_trace, log_debug, log_info, log_warn, log_error, error
         :undoc-members:
 
     .. autoclass:: StormConfig

--- a/pyleus/storm/__init__.py
+++ b/pyleus/storm/__init__.py
@@ -6,6 +6,12 @@ from collections import namedtuple
 
 DEFAULT_STREAM = "default"
 
+LOG_TRACE = 0
+LOG_DEBUG = 1
+LOG_INFO = 2
+LOG_WARN = 3
+LOG_ERROR = 4
+
 StormTuple = namedtuple('StormTuple', "id comp stream task values")
 """Namedtuple representing a Storm tuple.
 

--- a/pyleus/storm/component.py
+++ b/pyleus/storm/component.py
@@ -325,37 +325,68 @@ class Component(object):
 
         self._serializer.send_msg(command_dict)
 
-    def log(self, msg, level=None):
-        """Send a log message. Available log levels are LOG_TRACE, LOG_DEBUG,
-        LOG_INFO, LOG_WARN, LOG_ERROR.
+    def log(self, msg, level=LOG_INFO):
+        """Send a log message.
+
+        :param msg: log message
+        :type msg: ``str``
+        :param level:
+         log levels defined as constants in :mod:`pyleus.storm`.
+         Allowed: ``LOG_TRACE``, ``LOG_DEBUG``, ``LOG_INFO``, ``LOG_WARN``,
+         ``LOG_ERROR``. Default: ``LOG_INFO``
+        :type stream: ``int``
         """
         self.send_command('log', {
             'msg': msg,
-            'level': level or LOG_INFO,
+            'level': level,
         })
 
     def log_trace(self, msg):
-        """Send a log message with level LOG_TRACE."""
+        """Send a log message with level LOG_TRACE.
+
+        :param msg: log message
+        :type msg: ``str``
+        """
         self.log(msg, level=LOG_TRACE)
 
     def log_debug(self, msg):
-        """Send a log message with level LOG_DEBUG."""
+        """Send a log message with level LOG_DEBUG.
+
+        :param msg: log message
+        :type msg: ``str``
+        """
         self.log(msg, level=LOG_DEBUG)
 
     def log_info(self, msg):
-        """Send a log message with level LOG_INFO."""
+        """Send a log message with level LOG_INFO.
+
+        :param msg: log message
+        :type msg: ``str``
+        """
         self.log(msg, level=LOG_INFO)
 
     def log_warn(self, msg):
-        """Send a log message with level LOG_WARN."""
+        """Send a log message with level LOG_WARN.
+
+        :param msg: log message
+        :type msg: ``str``
+        """
         self.log(msg, level=LOG_WARN)
 
     def log_error(self, msg):
-        """Send a log message with level LOG_ERROR."""
+        """Send a log message with level LOG_ERROR.
+
+        :param msg: log message
+        :type msg: ``str``
+        """
         self.log(msg, level=LOG_ERROR)
 
     def error(self, msg):
-        """Send an error message."""
+        """Send an error message.
+
+        :param msg: error message
+        :type msg: ``str``
+        """
         self.send_command('error', {
             'msg': msg,
         })

--- a/pyleus/storm/component.py
+++ b/pyleus/storm/component.py
@@ -18,6 +18,11 @@ except ImportError:
     import json
 
 from pyleus.storm import DEFAULT_STREAM
+from pyleus.storm import LOG_TRACE
+from pyleus.storm import LOG_DEBUG
+from pyleus.storm import LOG_INFO
+from pyleus.storm import LOG_WARN
+from pyleus.storm import LOG_ERROR
 from pyleus.storm import StormTuple
 from pyleus.storm.serializers.msgpack_serializer import MsgpackSerializer
 from pyleus.storm.serializers.json_serializer import JSONSerializer
@@ -320,11 +325,34 @@ class Component(object):
 
         self._serializer.send_msg(command_dict)
 
-    def log(self, msg):
-        """Send a log message."""
+    def log(self, msg, level=None):
+        """Send a log message. Available log levels are LOG_TRACE, LOG_DEBUG,
+        LOG_INFO, LOG_WARN, LOG_ERROR.
+        """
         self.send_command('log', {
             'msg': msg,
+            'level': level or LOG_INFO,
         })
+
+    def log_trace(self, msg):
+        """Send a log message with level LOG_TRACE."""
+        self.log(msg, level=LOG_TRACE)
+
+    def log_debug(self, msg):
+        """Send a log message with level LOG_DEBUG."""
+        self.log(msg, level=LOG_DEBUG)
+
+    def log_info(self, msg):
+        """Send a log message with level LOG_INFO."""
+        self.log(msg, level=LOG_INFO)
+
+    def log_warn(self, msg):
+        """Send a log message with level LOG_WARN."""
+        self.log(msg, level=LOG_WARN)
+
+    def log_error(self, msg):
+        """Send a log message with level LOG_ERROR."""
+        self.log(msg, level=LOG_ERROR)
 
     def error(self, msg):
         """Send an error message."""

--- a/topology_builder/pom.xml
+++ b/topology_builder/pom.xml
@@ -33,13 +33,13 @@
     <dependency>
       <groupId>org.apache.storm</groupId>
       <artifactId>storm-core</artifactId>
-      <version>0.9.2-incubating</version>
+      <version>0.9.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.storm</groupId>
       <artifactId>storm-kafka</artifactId>
-      <version>0.9.2-incubating</version>
+      <version>0.9.3</version>
     </dependency>
     <dependency>
         <groupId>org.apache.kafka</groupId>

--- a/topology_builder/src/main/java/com/yelp/pyleus/serializer/MessagePackSerializer.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/serializer/MessagePackSerializer.java
@@ -97,6 +97,13 @@ public class MessagePackSerializer implements ISerializer {
             shellMsg.setMsg(log.asRawValue().getString());
         }
 
+        if (command.equals("log")) {
+            Value logLevelValue = msg.get("level");
+            if (logLevelValue != null) {
+                shellMsg.setLogLevel(logLevelValue.asIntegerValue().getInt());
+            }
+        }
+
         String stream = Utils.DEFAULT_STREAM_ID;
         Value streamValue = msg.get("stream");
         if (streamValue != null) {


### PR DESCRIPTION
This change add supports for Storm logging levels, introduced in 0.9.3 as described in #10. It also upgrade `pom.xml` Storm dependency to version 0.9.3 

Closes #10 
