### PR TITLE
Correction yaml.rst

### DIFF
--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -91,7 +91,7 @@ These options belong to the block associated either with a ``spout`` or a ``bolt
 
 * **tasks**\(``int``\)
 
-  Number of tasks per executor.
+  Number of tasks per component.
 
 * **tick_freq_secs**\(``float``\)[only for ``bolt``]
 


### PR DESCRIPTION
tasks: Number of tasks per component NOT executor.
