### PR TITLE
Add configuration option for brokerZkPath in Kafka Spouts

### DIFF
--- a/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
@@ -34,6 +34,7 @@ public class PyleusTopologyBuilder {
 
     public static final String YAML_FILENAME = "/resources/pyleus_topology.yaml";
     public static final String KAFKA_ZK_ROOT_FMT = "/pyleus-kafka-offsets/%s";
+    public static final String KAFKA_BROKER_ZK_PATH = "/brokers/";
     public static final String KAFKA_CONSUMER_ID_FMT = "pyleus-%s";
     public static final String MSGPACK_SERIALIZER_CLASS = "com.yelp.pyleus.serializer.MessagePackSerializer";
 
@@ -134,14 +135,19 @@ public class PyleusTopologyBuilder {
         if (zkRoot == null) {
             zkRoot = String.format(KAFKA_ZK_ROOT_FMT, spec.name);
         }
-
+        
+        String brokerZkPath = (String) spec.options.get("broker_zk_path");
+        if (brokerZkPath == null) {
+        	brokerZkPath = KAFKA_BROKER_ZK_PATH;
+        }
+        
         String consumerId = (String) spec.options.get("consumer_id");
         if (consumerId == null) {
             consumerId = String.format(KAFKA_CONSUMER_ID_FMT, spec.name);
         }
 
         SpoutConfig config = new SpoutConfig(
-            new ZkHosts(zkHosts),
+            new ZkHosts(zkHosts,brokerZkPath),
             topic,
             zkRoot,
             consumerId


### PR DESCRIPTION
This should address the issue in https://github.com/Yelp/pyleus/issues/124  . It builds on the fix offered in https://github.com/Yelp/pyleus/pull/128  and provides a yaml config option for the broker zookeeper path. The config option is 'broker_zk_path'.   The means of these configuration options can be found at https://github.com/apache/storm/tree/master/external/storm-kafka#zkhosts
