### PR TITLE
Change default zk_root and consumer_id to use topology name.

### DIFF
--- a/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
@@ -101,7 +101,7 @@ public class PyleusTopologyBuilder {
 
         IRichSpout spout;
         if (spec.type.equals("kafka")) {
-            spout = handleKafkaSpout(builder, spec);
+            spout = handleKafkaSpout(builder, spec, topologySpec);
         } else {
             spout = handlePythonSpout(builder, spec, topologySpec);
         }
@@ -120,7 +120,8 @@ public class PyleusTopologyBuilder {
 
     public static IRichSpout handleKafkaSpout(
             @SuppressWarnings("unused") final TopologyBuilder builder,
-            final SpoutSpec spec) {
+            final SpoutSpec spec,
+            final TopologySpec topologySpec) {
         String topic = (String) spec.options.get("topic");
         if (topic == null) {
             throw new RuntimeException("Kafka spout must have topic");
@@ -133,7 +134,7 @@ public class PyleusTopologyBuilder {
 
         String zkRoot = (String) spec.options.get("zk_root");
         if (zkRoot == null) {
-            zkRoot = String.format(KAFKA_ZK_ROOT_FMT, spec.name);
+            zkRoot = String.format(KAFKA_ZK_ROOT_FMT, topologySpec.name);
         }
         
         String brokerZkPath = (String) spec.options.get("broker_zk_path");
@@ -143,7 +144,7 @@ public class PyleusTopologyBuilder {
         
         String consumerId = (String) spec.options.get("consumer_id");
         if (consumerId == null) {
-            consumerId = String.format(KAFKA_CONSUMER_ID_FMT, spec.name);
+            consumerId = String.format(KAFKA_CONSUMER_ID_FMT, topologySpec.name);
         }
 
         SpoutConfig config = new SpoutConfig(


### PR DESCRIPTION
... to match the documentation. It was using the spout name.
Using the spout name was dangerous since many topologies reuse spout names.
