### PR TITLE
Kill the topology before shutting down in local mode.

### DIFF
--- a/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
+++ b/topology_builder/src/main/java/com/yelp/pyleus/PyleusTopologyBuilder.java
@@ -234,6 +234,11 @@ public class PyleusTopologyBuilder {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             public void run() {
                 try {
+                    cluster.killTopology(topologyName);
+                } catch (Exception e) {
+                    System.err.println(e.toString());
+                }
+                try {
                     cluster.shutdown();
                 } catch (Exception e) {
                     System.err.println(e.toString());


### PR DESCRIPTION
The shutdown process tended to hang if the topology was misbehaving. Killing the topology first seems to work better.
