### PR TITLE
fix the error when build under Chinese OS with default GBK encode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class sdist(_sdist):
 
 
 def readme():
-    with open("README.rst") as f:
+    with open("README.rst", encoding='utf-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
Because the "README.rst" is using "utf-8" encoded, and Chinese OS default encode is GBK, When build under Chinese  Windows OS, it will report:
Traceback (most recent call last):
  File "setup.py", line 81, in <module>
    long_description=readme(),
  File "setup.py", line 65, in readme
    return f.read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0x99 in position 878: illegal multibyte sequence
